### PR TITLE
Use sticky titles in multi-day events

### DIFF
--- a/src/components/events-blocks/week-view/AllDayEventBlock.tsx
+++ b/src/components/events-blocks/week-view/AllDayEventBlock.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react"
 
 import { EventContextMenu } from "@/components/EventContextMenu"
+import { GUTTER_WIDTH } from "@/components/main/week-view/WeekTimeGrid"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
 import type { AllDayLaneItem } from "@/hooks/cal-events/useMonthEventLayout"
@@ -20,9 +21,9 @@ export function WeekAllDayBar({
   onClick,
 }: {
   item: AllDayLaneItem
-  /** Added to item.startCol/endCol so the bar aligns with the parent grid's day columns. */
+  // Added to item.startCol/endCol so bar aligns with the parent grid's day columns:
   colOffset: number
-  /** Added to item.lane so the bar lands on the right row in the parent grid. */
+  // Added to item.lane so bar lands on the right row in the parent grid:
   rowOffset: number
   isActive: boolean
   isPending: boolean
@@ -51,7 +52,7 @@ export function WeekAllDayBar({
         data-event-clickable={!isDraft || undefined}
         className={cn(
           getEventBlockClasses(highlighted, isDeclined),
-          "truncate px-1 py-px leading-4 rounded",
+          "flex items-center px-1 py-px leading-4 rounded",
           !isDraft && dimmed && "opacity-50",
           isDraft && "font-medium",
         )}
@@ -72,7 +73,10 @@ export function WeekAllDayBar({
               }
         }
       >
-        {item.event.summary || <UntitledEventText />}
+        {/* Make title in multi-day event sticky so it stays visible when user scrolls: */}
+        <span className="sticky truncate min-w-0" style={{ left: GUTTER_WIDTH + 4 }}>
+          {item.event.summary || <UntitledEventText />}
+        </span>
       </div>
     </div>
   )

--- a/src/components/main/week-view/WeekTimeGrid.tsx
+++ b/src/components/main/week-view/WeekTimeGrid.tsx
@@ -35,7 +35,7 @@ import { ScheduledDayContextMenu } from "./ScheduledDayContextMenu"
 
 const HOUR_HEIGHT = 56
 const GRID_HEIGHT = 24 * HOUR_HEIGHT
-const GUTTER_WIDTH = 48
+export const GUTTER_WIDTH = 48
 const DAY_WIDTH_MIN = 100
 
 // How long to wait after a scroll event before considering the scroll "settled"


### PR DESCRIPTION
So that the user always sees the title of their multi-day events when scrolling.

**Before:**

https://github.com/user-attachments/assets/e0723bd7-e944-4679-ac89-3e3d2a5362ae

**After:**

https://github.com/user-attachments/assets/300a21f0-5a16-400c-9ef0-4644e037e2aa


