### PR TITLE
feat: add board view and settings window close button

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -543,6 +543,8 @@ dependencies = [
 [[package]]
 name = "caldir-core"
 version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7085384510ed75c303119e600d4bda6045c139409ac8cb2a5c11407bf8995983"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:webview:allow-create-webview-window",
     "core:window:allow-center",
     "notification:default",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "core:window:allow-close"
   ]
 }

--- a/src/components/main/Main.tsx
+++ b/src/components/main/Main.tsx
@@ -1,4 +1,5 @@
 import { MainHeader } from "@/components/main/MainHeader"
+import { BoardView } from "@/components/main/board-view/BoardView"
 import { MonthView } from "@/components/main/month-view/MonthView"
 import { WeekView } from "@/components/main/week-view/WeekView"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
@@ -26,6 +27,9 @@ export function Main({
         </TabsContent>
         <TabsContent value="month" className="h-full">
           <MonthView />
+        </TabsContent>
+        <TabsContent value="board" className="h-full">
+          <BoardView />
         </TabsContent>
       </div>
     </Tabs>

--- a/src/components/main/MainHeader.tsx
+++ b/src/components/main/MainHeader.tsx
@@ -36,6 +36,7 @@ export function MainHeader() {
       <TabsList onMouseDown={(e) => e.preventDefault()} tabIndex={-1}>
         <CalendarViewTab view="week" name="Week" shortcut="w" />
         <CalendarViewTab view="month" name="Month" shortcut="m" />
+        <CalendarViewTab view="board" name="Board" shortcut="b" />
       </TabsList>
 
       <SearchBar className="w-56 starting:w-56" eventPopoverSide="left" />

--- a/src/components/main/board-view/BoardCard.tsx
+++ b/src/components/main/board-view/BoardCard.tsx
@@ -1,0 +1,79 @@
+import { format } from "date-fns"
+import type { MouseEvent } from "react"
+import { memo, useMemo } from "react"
+
+import { UntitledEventText } from "@/components/ui/untitled-event-text"
+
+import { useCalEvents } from "@/contexts/CalEventsContext"
+import { useCalendars } from "@/contexts/CalendarStateContext"
+import { useSettings } from "@/contexts/SettingsContext"
+
+import { CalendarEvent, eventKey } from "@/lib/cal-events"
+import { getCalendarColor } from "@/lib/calendar-styles"
+import { setEventAnchor } from "@/lib/event-anchor"
+import { getEventBlockColors } from "@/lib/event-styles"
+import { formatShortDate, formatTime, isSameDay, toInteropDate } from "@/lib/event-time"
+
+export const BoardCard = memo(function BoardCard({
+  event,
+  showDate,
+}: {
+  event: CalendarEvent
+  showDate?: boolean
+}) {
+  const { timeFormat } = useSettings()
+  const { calendars } = useCalendars()
+  const calendarBySlug = useMemo(() => new Map(calendars.map((c) => [c.slug, c])), [calendars])
+  const calendarColor = getCalendarColor(calendarBySlug.get(event.calendar_slug))
+  const colors = getEventBlockColors({ calendarColor, eventColor: event.color })
+  const { toggleActiveEventKey } = useCalEvents()
+
+  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation()
+    setEventAnchor(e.currentTarget)
+    toggleActiveEventKey(eventKey(event))
+  }
+
+  return (
+    <div
+      className="cursor-default hover:bg-secondary py-1.5 border-b border-divider last:border-b-0 outline-none"
+      data-event-clickable
+      onClick={handleClick}
+    >
+      <div className="flex gap-3 pl-3 pr-2">
+        {/* Left accent bar — no rounding, matches event blocks in other views */}
+        <div
+          className="w-[3px] shrink-0 self-stretch"
+          style={{ backgroundColor: colors.borderColor }}
+        />
+        <div className="min-w-0">
+          {showDate && (
+            <div className="text-xs text-muted-foreground numerical h-4">
+              {formatShortDate(event.start)}
+            </div>
+          )}
+
+          <div className="text-sm font-medium truncate">
+            {event.summary || <UntitledEventText />}
+          </div>
+
+          {event.start.kind !== "date" && (
+            <div className="text-muted-foreground numerical text-xs h-4">
+              {isSameDay(event.start, event.end)
+                ? `${formatTime(event.start, timeFormat)} - ${formatTime(event.end, timeFormat)}`
+                : `${format(toInteropDate(event.start), "MMM d,")} ${formatTime(event.start, timeFormat)} - ${format(toInteropDate(event.end), "MMM d,")} ${formatTime(event.end, timeFormat)}`}
+            </div>
+          )}
+
+          {event.start.kind === "date" && (
+            <div className="text-xs text-muted-foreground h-4">All day</div>
+          )}
+
+          {event.location && (
+            <div className="text-xs text-muted-foreground truncate">{event.location}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+})

--- a/src/components/main/board-view/BoardColumn.tsx
+++ b/src/components/main/board-view/BoardColumn.tsx
@@ -1,0 +1,60 @@
+import { BoardCard } from "@/components/main/board-view/BoardCard"
+
+import { CalendarEvent } from "@/lib/cal-events"
+import { cn } from "@/lib/utils"
+
+export function BoardColumn({
+  title,
+  events,
+  showDate,
+  isToday,
+  isLast,
+  className,
+}: {
+  title: string
+  events: CalendarEvent[]
+  showDate?: boolean
+  isToday?: boolean
+  isLast?: boolean
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col flex-1 min-w-0 border-r border-divider overflow-hidden",
+        isLast && "border-r-0",
+        className,
+      )}
+    >
+      {/* Column header — matches the weekday label bar style */}
+      <div
+        className={cn(
+          "flex items-center justify-between px-3 py-2 border-b border-divider shrink-0",
+          isToday && "bg-accent",
+        )}
+      >
+        <span className="text-[11px] text-muted-foreground font-medium numerical uppercase tracking-wide">
+          {title}
+        </span>
+        <span className="text-[11px] text-muted-foreground numerical tabular-nums">
+          {events.length > 0 ? events.length : ""}
+        </span>
+      </div>
+
+      {/* Event list */}
+      <div className="flex flex-col overflow-y-auto grow">
+        {events.map((event) => (
+          <BoardCard
+            key={`${event.calendar_slug}::${event.id}`}
+            event={event}
+            showDate={showDate}
+          />
+        ))}
+
+        {events.length === 0 && (
+          <div className="text-xs text-muted-foreground text-center py-8 numerical">—</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/main/board-view/BoardView.tsx
+++ b/src/components/main/board-view/BoardView.tsx
@@ -1,0 +1,108 @@
+import { Temporal } from "@js-temporal/polyfill"
+import { useMemo } from "react"
+
+import { BoardColumn } from "@/components/main/board-view/BoardColumn"
+
+import { useCalEvents } from "@/contexts/CalEventsContext"
+
+import { type CalendarEvent } from "@/lib/cal-events"
+import { dateInViewerZone } from "@/lib/event-time"
+import { getLocalTzid } from "@/lib/event-time/local-zone"
+
+interface Bucket {
+  id: string
+  title: string
+  events: CalendarEvent[]
+  showDate: boolean
+  isToday: boolean
+}
+
+function eventDateKey(event: CalendarEvent): string {
+  const pd = dateInViewerZone(event.start)
+  return pd.toString()
+}
+
+export function BoardView() {
+  const { calendarEvents } = useCalEvents()
+
+  const columns = useMemo(() => {
+    const today = Temporal.Now.zonedDateTimeISO(getLocalTzid()).toPlainDate()
+    const yesterday = today.subtract({ days: 1 })
+    const tomorrow = today.add({ days: 1 })
+
+    const dayOfWeek = today.dayOfWeek
+    const daysUntilSunday = 7 - dayOfWeek
+    const endOfWeek = today.add({ days: daysUntilSunday })
+
+    function getBucketId(pd: Temporal.PlainDate): string {
+      if (pd.equals(yesterday)) return "yesterday"
+      if (pd.equals(today)) return "today"
+      if (pd.equals(tomorrow)) return "tomorrow"
+      if (
+        Temporal.PlainDate.compare(pd, tomorrow) > 0 &&
+        Temporal.PlainDate.compare(pd, endOfWeek) <= 0
+      )
+        return "this-week"
+      return "past"
+    }
+
+    const bucketDefs: Record<string, { title: string; showDate: boolean; isToday: boolean }> = {
+      yesterday: { title: "Yesterday", showDate: false, isToday: false },
+      today: { title: "Today", showDate: false, isToday: true },
+      tomorrow: { title: "Tomorrow", showDate: false, isToday: false },
+      "this-week": { title: "This Week", showDate: true, isToday: false },
+    }
+
+    const buckets = new Map<string, CalendarEvent[]>()
+
+    for (const event of calendarEvents) {
+      const pd = dateInViewerZone(event.start)
+      const bucketId = getBucketId(pd)
+      if (bucketId === "past") continue
+
+      const group = buckets.get(bucketId)
+      if (group) {
+        group.push(event)
+      } else {
+        buckets.set(bucketId, [event])
+      }
+    }
+
+    const orderedIds = ["yesterday", "today", "tomorrow", "this-week"]
+
+    return orderedIds.map((id) => {
+      const def = bucketDefs[id]
+      const events = buckets.get(id) ?? []
+      if (id === "this-week") {
+        events.sort((a, b) => {
+          const aKey = eventDateKey(a)
+          const bKey = eventDateKey(b)
+          if (aKey !== bKey) return aKey < bKey ? -1 : 1
+          return a.dateInfo.startMs - b.dateInfo.startMs
+        })
+      }
+      return {
+        id,
+        title: def.title,
+        events,
+        showDate: def.showDate,
+        isToday: def.isToday,
+      } satisfies Bucket
+    })
+  }, [calendarEvents])
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      {columns.map((col, i) => (
+        <BoardColumn
+          key={col.id}
+          title={col.title}
+          events={col.events}
+          showDate={col.showDate}
+          isToday={col.isToday}
+          isLast={i === columns.length - 1}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/shortcuts/GlobalShortcuts.tsx
+++ b/src/components/shortcuts/GlobalShortcuts.tsx
@@ -145,6 +145,7 @@ function useShortcutHandlers({
     },
     month: () => onChangeCalendarView("month"),
     week: () => onChangeCalendarView("week"),
+    board: () => onChangeCalendarView("board"),
     search: handleSearch,
     "new-event": handleNewEvent,
     settings: (e) => {

--- a/src/lib/calendar-view.ts
+++ b/src/lib/calendar-view.ts
@@ -1,6 +1,6 @@
 import z from "zod"
 
-export const calendarViewSchema = z.enum(["week", "month"])
+export const calendarViewSchema = z.enum(["week", "month", "board"])
 
 export type CalendarView = z.infer<typeof calendarViewSchema>
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -79,6 +79,12 @@ export const SHORTCUTS = [
     bindings: [{ keys: "m", type: "char" }],
   },
   {
+    id: "board",
+    group: "View",
+    label: "Board view",
+    bindings: [{ keys: "b", type: "char" }],
+  },
+  {
     id: "week",
     group: "View",
     label: "Week view",

--- a/src/windows/SettingsWindow.tsx
+++ b/src/windows/SettingsWindow.tsx
@@ -1,14 +1,30 @@
-import { useState } from "react"
+import { getCurrentWindow } from "@tauri-apps/api/window"
+import { useEffect, useState } from "react"
 
 import { NAV_ITEMS, SettingsSidebar, SettingsTab } from "@/components/settings/SettingsSidebar"
 import { DragRegion } from "@/components/ui/drag-region"
+import { ShortcutTooltip } from "@/components/ui/shortcut-tooltip"
 
 import { useTheme } from "@/hooks/useTheme"
 import { cn, isMacOS } from "@/lib/utils"
 
+import { CloseIcon } from "@/icons/close"
+
 export function SettingsWindow() {
   const [activeTab, setActiveTab] = useState<SettingsTab>("general")
   useTheme()
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        getCurrentWindow()
+          .close()
+          .catch(() => {})
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [])
 
   const activeItem = NAV_ITEMS.find((item) => item.tab === activeTab)
   if (!activeItem) return null
@@ -17,6 +33,20 @@ export function SettingsWindow() {
   return (
     <div className={cn("flex h-screen", { "pt-8": isMacOS })}>
       <DragRegion className="absolute top-0 left-0 right-0 h-5!" />
+
+      <ShortcutTooltip text="Close" shortcut="escape">
+        <button
+          onClick={() =>
+            getCurrentWindow()
+              .close()
+              .catch(() => {})
+          }
+          className="absolute top-2 right-2 z-50 rounded-sm p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring"
+          aria-label="Close"
+        >
+          <CloseIcon className="size-4" />
+        </button>
+      </ShortcutTooltip>
 
       <SettingsSidebar activeTab={activeTab} onTabChange={setActiveTab} />
 

--- a/src/windows/SettingsWindow.tsx
+++ b/src/windows/SettingsWindow.tsx
@@ -17,9 +17,13 @@ export function SettingsWindow() {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        getCurrentWindow()
-          .close()
-          .catch(() => {})
+        setTimeout(() => {
+          if (!e.defaultPrevented) {
+            getCurrentWindow()
+              .close()
+              .catch(() => {})
+          }
+        }, 0)
       }
     }
     document.addEventListener("keydown", onKeyDown)


### PR DESCRIPTION
## Summary

Adds a new **Board View** (kanban-style calendar view) and improves the **Settings window** with a close button and ESC shortcut.

## Board View

<img width="1896" height="1008" alt="image" src="https://github.com/user-attachments/assets/8bfae535-ebfd-4bcf-9874-3d7aa6a9f436" />

A new calendar view that groups events into time-based columns:
- **Yesterday** — events from the previous day
- **Today** — events for the current day (highlighted)
- **Tomorrow** — events for the next day
- **This Week** — remaining events in the current week (with date labels, sorted by date then time)

Each event card shows:
- Color accent bar (matching calendar/event color)
- Event title (or "Untitled" placeholder)
- Time range (for timed events) or "All day" label
- Location (if present)
- Date labels in the \"This Week\" column

### Files
- `src/components/main/board-view/BoardView.tsx` — Bucket logic using `@js-temporal/polyfill`, memoized column computation
- `src/components/main/board-view/BoardColumn.tsx` — Column layout with header, event count badge, and scrollable event list
- `src/components/main/board-view/BoardCard.tsx` — Individual event card with click-to-open-popover behavior

### Integration
- Added `"board"` to `calendarViewSchema` in `src/lib/calendar-view.ts`
- Added keyboard shortcut `b` for board view in `src/lib/shortcuts.ts`
- Board view tab renders in the main view switcher (`MainHeader.tsx`)
- `BoardView` rendered inside `Main.tsx` via `TabsContent`

## Settings Window Close Button

The settings window (a separate Tauri webview) previously had no close mechanism other than the OS window chrome. On Linux (where `decorations: false`), there was no way to close it.

<img width="1036" height="726" alt="image" src="https://github.com/user-attachments/assets/07426dd3-e6ad-4184-bd72-0fb0f4462981" />


### Changes
- **Close icon** (X) added to the top-right corner of `SettingsWindow.tsx`
- **ESC key** listener closes the window
- **Tooltip** on hover: \"Close Esc\"
- Uses existing `CloseIcon` and `ShortcutTooltip` components

### Tauri Permissions
- Added `core:window:allow-close` to `src-tauri/capabilities/default.json` — required for programmatic window close in Tauri v2

## Minor
- `pnpm-workspace.yaml` — new workspace configuration file