### PR TITLE
Custom themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>renCal</title>
     <style>
-      /* Flash-prevention before CSS loads. Add a rule per theme when
-         registering new themes in src/themes/manifest.ts. */
-      body[data-theme="classic"],
-      body:not([data-theme])[data-default-theme="classic"] {
-        background-color: #1a1b26;
-      }
-      body[data-theme="ren"],
-      body:not([data-theme])[data-default-theme="ren"] {
+      /* Fallback background before the CSS bundle loads, for a first-ever launch
+         with no cached background yet. The cached value (any active theme,
+         including user-supplied ones) is applied inline by the script below. */
+      html {
         background-color: #131313;
-      }
-      body[data-theme="omarchy"],
-      body:not([data-theme])[data-default-theme="omarchy"] {
-        background-color: #1a1b26;
       }
     </style>
   </head>
@@ -31,17 +23,17 @@
       } catch {
         document.body.dataset.theme = DEFAULT_THEME
       }
-      // For the Omarchy theme, apply the last-known background from cache so the
-      // flash-prevention rule above doesn't paint a stale color while React boots.
-      if (document.body.dataset.theme === "omarchy") {
-        try {
-          const cached = JSON.parse(localStorage.getItem("omarchyColors"))
-          if (cached && cached.background) {
-            document.body.style.setProperty("--background", cached.background)
-            document.documentElement.style.backgroundColor = cached.background
-          }
-        } catch {}
-      }
+      // Apply the active theme's last-known background so we don't flash a stale
+      // color before the CSS bundle (and any user-theme <style>) loads. Works
+      // for every theme — built-in, omarchy, or user-supplied — because
+      // useTheme caches the resolved --background on each change.
+      try {
+        const bg = localStorage.getItem("themeBackground")
+        if (bg) {
+          document.body.style.setProperty("--background", bg)
+          document.documentElement.style.backgroundColor = bg
+        }
+      } catch {}
     </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "opener:allow-open-path",
     "core:window:allow-start-dragging",
     "core:window:allow-set-focus",
     "core:webview:allow-create-webview-window",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "opener:allow-open-path",
     "core:window:allow-start-dragging",
     "core:window:allow-set-focus",
     "core:webview:allow-create-webview-window",

--- a/src-tauri/rencal-config/src/lib.rs
+++ b/src-tauri/rencal-config/src/lib.rs
@@ -41,11 +41,16 @@ impl Default for RencalConfig {
 }
 
 impl RencalConfig {
+    /// `~/.config/rencal` — the directory holding all renCal user files
+    /// (config.toml, the `themes/` directory, etc.).
+    pub fn config_dir() -> Result<PathBuf, String> {
+        dirs::config_dir()
+            .ok_or_else(|| "Could not resolve user config directory".to_string())
+            .map(|d| d.join("rencal"))
+    }
+
     pub fn config_path() -> Result<PathBuf, String> {
-        let dir = dirs::config_dir()
-            .ok_or_else(|| "Could not resolve user config directory".to_string())?
-            .join("rencal");
-        Ok(dir.join("config.toml"))
+        Ok(Self::config_dir()?.join("config.toml"))
     }
 
     pub fn exists() -> bool {

--- a/src-tauri/rencal-config/src/lib.rs
+++ b/src-tauri/rencal-config/src/lib.rs
@@ -41,8 +41,7 @@ impl Default for RencalConfig {
 }
 
 impl RencalConfig {
-    /// `~/.config/rencal` — the directory holding all renCal user files
-    /// (config.toml, the `themes/` directory, etc.).
+    /// ~/.config/rencal
     pub fn config_dir() -> Result<PathBuf, String> {
         dirs::config_dir()
             .ok_or_else(|| "Could not resolve user config directory".to_string())

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -1,11 +1,5 @@
 //! User-supplied CSS themes loaded from `~/.config/rencal/themes/`.
-//!
-//! Each `*.css` file in that directory becomes a selectable theme. The file
-//! holds a bare block of CSS custom-property declarations (no selector); the
-//! frontend wraps it in `[data-theme="user:<slug>"] { … }` when injecting, so
-//! authors never write the scoping selector themselves. This mirrors the
-//! Omarchy pipeline (see `crate::omarchy`): scan on demand, watch the dir, and
-//! emit on change so added/edited themes show up live.
+//! The frontend wraps it in `[data-theme="user:<slug>"] { … }` when injecting.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -34,8 +28,7 @@ fn themes_dir() -> Option<PathBuf> {
     RencalConfig::config_dir().ok().map(|d| d.join("themes"))
 }
 
-/// Resolve the themes dir, creating it if missing so users have somewhere to
-/// drop files and the watcher has a directory to watch. Best-effort.
+// Create ~/.config/rencal/themes/ if it doesn't exist
 fn ensure_themes_dir() -> Option<PathBuf> {
     let dir = themes_dir()?;
     if !dir.exists() {
@@ -135,8 +128,7 @@ pub fn scan() -> Vec<ExternalTheme> {
     themes
 }
 
-/// Watches `~/.config/rencal/themes/` and emits `EXTERNAL_THEMES_CHANGED` with
-/// the full theme list whenever a file is added, edited, or removed.
+/// Watches `~/.config/rencal/themes/` and emits `EXTERNAL_THEMES_CHANGED` when anything changes
 pub async fn run_watcher(app: AppHandle) {
     let Some(watch_dir) = ensure_themes_dir() else {
         return;

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -16,11 +16,9 @@ pub const EXTERNAL_THEMES_CHANGED: &str = "external-themes-changed";
 
 #[derive(Clone, Debug, Deserialize, Serialize, Type)]
 pub struct ExternalTheme {
-    /// Stable id, namespaced to avoid colliding with built-in themes.
     pub id: String,
-    /// Display name from an optional `@name` comment directive, else the filename.
+    /// Uses `@name` (or filename as fallback)
     pub name: String,
-    /// Raw file contents (a bare declaration block, no selector).
     pub css: String,
 }
 
@@ -38,7 +36,6 @@ fn ensure_themes_dir() -> Option<PathBuf> {
     Some(dir)
 }
 
-/// Drop a README so first-time users see the expected format.
 fn write_readme(dir: &std::path::Path) {
     let readme = r#"renCal custom themes
 ====================
@@ -78,8 +75,6 @@ fn slugify(input: &str) -> String {
     out
 }
 
-/// Pull a display name from a leading `@name <value>` directive in a comment,
-/// falling back to the provided default.
 fn parse_name(css: &str, fallback: &str) -> String {
     if let Some(idx) = css.find("@name") {
         let rest = &css[idx + "@name".len()..];

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -51,10 +51,6 @@ fn write_readme(dir: &std::path::Path) {
     let _ = std::fs::write(dir.join("README.txt"), readme);
 }
 
-pub fn themes_dir_string() -> Option<String> {
-    Some(ensure_themes_dir()?.to_string_lossy().into_owned())
-}
-
 /// Lowercase, collapse non-alphanumeric runs to single `-`, trim leading/trailing `-`.
 fn slugify(input: &str) -> String {
     let mut out = String::new();

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -1,0 +1,186 @@
+//! User-supplied CSS themes loaded from `~/.config/rencal/themes/`.
+//!
+//! Each `*.css` file in that directory becomes a selectable theme. The file
+//! holds a bare block of CSS custom-property declarations (no selector); the
+//! frontend wraps it in `[data-theme="user:<slug>"] { … }` when injecting, so
+//! authors never write the scoping selector themselves. This mirrors the
+//! Omarchy pipeline (see `crate::omarchy`): scan on demand, watch the dir, and
+//! emit on change so added/edited themes show up live.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecursiveMode, Watcher};
+use rencal_config::RencalConfig;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+pub const EXTERNAL_THEMES_CHANGED: &str = "external-themes-changed";
+
+#[derive(Clone, Debug, Deserialize, Serialize, Type)]
+pub struct ExternalTheme {
+    /// Stable id, namespaced to avoid colliding with built-in themes.
+    pub id: String,
+    /// Display name from an optional `@name` comment directive, else the filename.
+    pub name: String,
+    /// Raw file contents (a bare declaration block, no selector).
+    pub css: String,
+}
+
+fn themes_dir() -> Option<PathBuf> {
+    RencalConfig::config_dir().ok().map(|d| d.join("themes"))
+}
+
+/// Resolve the themes dir, creating it if missing so users have somewhere to
+/// drop files and the watcher has a directory to watch. Best-effort.
+fn ensure_themes_dir() -> Option<PathBuf> {
+    let dir = themes_dir()?;
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).ok()?;
+        write_readme(&dir);
+    }
+    Some(dir)
+}
+
+/// Drop a README so first-time users see the expected format.
+fn write_readme(dir: &std::path::Path) {
+    let readme = "renCal custom themes\n====================\n\nDrop a .css file in this folder and it shows up in Settings > Themes.\nThe filename becomes the theme name (override with a `@name` comment).\n\nA theme is a bare block of CSS variables — no selector needed:\n\n    /* @name My Theme */\n    --background: #0f1115;\n    --foreground: #e6e6e6;\n    --hover-tint: #ffffff;\n    --primary: #7c8cff;\n    --highlight: #7c8cff;\n\nSetting --background, --foreground, --hover-tint and --primary gets you most\nof a theme; hover/card/divider/etc. are derived automatically. Edits apply\nlive. See the full variable list in renCal's docs.\n";
+    let _ = std::fs::write(dir.join("README.txt"), readme);
+}
+
+pub fn themes_dir_string() -> Option<String> {
+    Some(ensure_themes_dir()?.to_string_lossy().into_owned())
+}
+
+/// Lowercase, collapse non-alphanumeric runs to single `-`, trim leading/trailing `-`.
+fn slugify(input: &str) -> String {
+    let mut out = String::new();
+    for c in input.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if !out.ends_with('-') && !out.is_empty() {
+            out.push('-');
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// Pull a display name from a leading `@name <value>` directive in a comment,
+/// falling back to the provided default.
+fn parse_name(css: &str, fallback: &str) -> String {
+    if let Some(idx) = css.find("@name") {
+        let rest = &css[idx + "@name".len()..];
+        let line = rest.lines().next().unwrap_or("");
+        let name = line.replace("*/", "");
+        let name = name.trim();
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    fallback.to_string()
+}
+
+pub fn scan() -> Vec<ExternalTheme> {
+    let Some(dir) = ensure_themes_dir() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut themes = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("css") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let slug = slugify(stem);
+        if slug.is_empty() {
+            continue;
+        }
+        let Ok(css) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        themes.push(ExternalTheme {
+            id: format!("user:{slug}"),
+            name: parse_name(&css, stem),
+            css,
+        });
+    }
+
+    themes.sort_by_key(|t| t.name.to_lowercase());
+    themes
+}
+
+/// Watches `~/.config/rencal/themes/` and emits `EXTERNAL_THEMES_CHANGED` with
+/// the full theme list whenever a file is added, edited, or removed.
+pub async fn run_watcher(app: AppHandle) {
+    let Some(watch_dir) = ensure_themes_dir() else {
+        return;
+    };
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+
+    let mut watcher = match notify::recommended_watcher(move |res: notify::Result<Event>| {
+        if let Ok(event) = res
+            && matches!(
+                event.kind,
+                EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_)
+            )
+        {
+            let _ = tx.send(());
+        }
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            log::warn!("Failed to init theme watcher: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        log::warn!("Failed to watch {watch_dir:?}: {e}");
+        return;
+    }
+
+    while rx.recv().await.is_some() {
+        // Coalesce editor save bursts.
+        sleep(Duration::from_millis(150)).await;
+        while rx.try_recv().is_ok() {}
+
+        let _ = app.emit(EXTERNAL_THEMES_CHANGED, scan());
+    }
+
+    drop(watcher);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_name, slugify};
+
+    #[test]
+    fn slugify_lowercases_and_collapses() {
+        assert_eq!(slugify("Tokyo Night"), "tokyo-night");
+        assert_eq!(slugify("My__Cool  Theme!!"), "my-cool-theme");
+        assert_eq!(slugify("  spaced  "), "spaced");
+        assert_eq!(slugify("already-slug"), "already-slug");
+        assert_eq!(slugify("***"), "");
+    }
+
+    #[test]
+    fn parse_name_reads_directive_else_fallback() {
+        assert_eq!(parse_name("/* @name My Theme */\n--background: #000;", "file"), "My Theme");
+        assert_eq!(parse_name("--background: #000;", "file"), "file");
+        // Trailing comment close is stripped, surrounding whitespace trimmed.
+        assert_eq!(parse_name("/*@name   Solar  */", "file"), "Solar");
+    }
+}

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -178,7 +178,10 @@ mod tests {
 
     #[test]
     fn parse_name_reads_directive_else_fallback() {
-        assert_eq!(parse_name("/* @name My Theme */\n--background: #000;", "file"), "My Theme");
+        assert_eq!(
+            parse_name("/* @name My Theme */\n--background: #000;", "file"),
+            "My Theme"
+        );
         assert_eq!(parse_name("--background: #000;", "file"), "file");
         // Trailing comment close is stripped, surrounding whitespace trimmed.
         assert_eq!(parse_name("/*@name   Solar  */", "file"), "Solar");

--- a/src-tauri/src/external_themes.rs
+++ b/src-tauri/src/external_themes.rs
@@ -47,7 +47,25 @@ fn ensure_themes_dir() -> Option<PathBuf> {
 
 /// Drop a README so first-time users see the expected format.
 fn write_readme(dir: &std::path::Path) {
-    let readme = "renCal custom themes\n====================\n\nDrop a .css file in this folder and it shows up in Settings > Themes.\nThe filename becomes the theme name (override with a `@name` comment).\n\nA theme is a bare block of CSS variables — no selector needed:\n\n    /* @name My Theme */\n    --background: #0f1115;\n    --foreground: #e6e6e6;\n    --hover-tint: #ffffff;\n    --primary: #7c8cff;\n    --highlight: #7c8cff;\n\nSetting --background, --foreground, --hover-tint and --primary gets you most\nof a theme; hover/card/divider/etc. are derived automatically. Edits apply\nlive. See the full variable list in renCal's docs.\n";
+    let readme = r#"renCal custom themes
+====================
+
+Drop a .css file in this folder and it shows up in Settings > Themes.
+The filename becomes the theme name (override with a `@name` comment).
+
+A theme is a bare block of CSS variables — no selector needed:
+
+    /* @name My Theme */
+    --background: #0f1115;
+    --foreground: #e6e6e6;
+    --hover-tint: #ffffff;
+    --primary: #7c8cff;
+    --highlight: #7c8cff;
+
+Setting --background, --foreground, --hover-tint and --primary gets you most
+of a theme; hover/card/divider/etc. are derived automatically. Edits apply
+live. See the full variable list in renCal's docs.
+"#;
     let _ = std::fs::write(dir.join("README.txt"), readme);
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod caldir_watcher;
 mod event_cache;
+mod external_themes;
 #[cfg(target_os = "linux")]
 mod linux_reminders;
 mod notifications;
@@ -13,6 +14,7 @@ use routes::caldir::{CaldirApi, CaldirApiImpl};
 use routes::config::{ConfigApi, ConfigApiImpl};
 use routes::omarchy::{OmarchyApi, OmarchyApiImpl};
 use routes::platform::{PlatformApi, PlatformApiImpl, needs_native_decorations};
+use routes::themes::{ThemesApi, ThemesApiImpl};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tauri::Manager;
@@ -35,6 +37,7 @@ pub fn create_router() -> Router<tauri::Wry> {
         .merge(OmarchyApiImpl.into_handler())
         .merge(PlatformApiImpl.into_handler())
         .merge(ConfigApiImpl.into_handler())
+        .merge(ThemesApiImpl.into_handler())
 }
 
 /// Resolve the bundled providers directory and remember it for `load_caldir`.
@@ -156,6 +159,9 @@ pub async fn run() {
 
             // Handle changing Omarchy theme:
             tokio::spawn(omarchy::run_watcher(app.handle().clone()));
+
+            // Handle user-supplied CSS themes in ~/.config/rencal/themes:
+            tokio::spawn(external_themes::run_watcher(app.handle().clone()));
 
             // Handle caldir file changes:
             tokio::spawn(caldir_watcher::run_watcher(app.handle().clone()));

--- a/src-tauri/src/routes/mod.rs
+++ b/src-tauri/src/routes/mod.rs
@@ -2,5 +2,6 @@ pub mod caldir;
 pub mod config;
 pub mod omarchy;
 pub mod platform;
+pub mod themes;
 
 pub type TauResult<T> = Result<T, String>;

--- a/src-tauri/src/routes/themes.rs
+++ b/src-tauri/src/routes/themes.rs
@@ -2,11 +2,9 @@ use crate::external_themes::{self, ExternalTheme};
 use crate::routes::TauResult;
 
 // list_external: user-supplied CSS themes discovered in ~/.config/rencal/themes/.
-// themes_dir: absolute path to that directory (for an "open folder" action).
 #[taurpc::procedures(path = "themes", export_to = "../src/rpc/bindings.ts")]
 pub trait ThemesApi {
     async fn list_external() -> TauResult<Vec<ExternalTheme>>;
-    async fn themes_dir() -> TauResult<String>;
 }
 
 #[derive(Clone)]
@@ -16,10 +14,5 @@ pub struct ThemesApiImpl;
 impl ThemesApi for ThemesApiImpl {
     async fn list_external(self) -> TauResult<Vec<ExternalTheme>> {
         Ok(external_themes::scan())
-    }
-
-    async fn themes_dir(self) -> TauResult<String> {
-        external_themes::themes_dir_string()
-            .ok_or_else(|| "Could not resolve themes directory".to_string())
     }
 }

--- a/src-tauri/src/routes/themes.rs
+++ b/src-tauri/src/routes/themes.rs
@@ -1,0 +1,25 @@
+use crate::external_themes::{self, ExternalTheme};
+use crate::routes::TauResult;
+
+// list_external: user-supplied CSS themes discovered in ~/.config/rencal/themes/.
+// themes_dir: absolute path to that directory (for an "open folder" action).
+#[taurpc::procedures(path = "themes", export_to = "../src/rpc/bindings.ts")]
+pub trait ThemesApi {
+    async fn list_external() -> TauResult<Vec<ExternalTheme>>;
+    async fn themes_dir() -> TauResult<String>;
+}
+
+#[derive(Clone)]
+pub struct ThemesApiImpl;
+
+#[taurpc::resolvers]
+impl ThemesApi for ThemesApiImpl {
+    async fn list_external(self) -> TauResult<Vec<ExternalTheme>> {
+        Ok(external_themes::scan())
+    }
+
+    async fn themes_dir(self) -> TauResult<String> {
+        external_themes::themes_dir_string()
+            .ok_or_else(|| "Could not resolve themes directory".to_string())
+    }
+}

--- a/src/components/settings/themes/ThemesPage.tsx
+++ b/src/components/settings/themes/ThemesPage.tsx
@@ -1,7 +1,3 @@
-import { openPath } from "@tauri-apps/plugin-opener"
-
-import { rpc } from "@/rpc"
-
 import { useTheme } from "@/hooks/useTheme"
 import { cn } from "@/lib/utils"
 
@@ -13,40 +9,9 @@ export function ThemesPage() {
   const { theme, setTheme } = useTheme()
   const { descriptors } = useThemeRegistry()
 
-  const builtins = descriptors.filter((d) => d.source === "builtin")
-  const externals = descriptors.filter((d) => d.source === "external")
-
-  async function openThemesFolder() {
-    try {
-      await openPath(await rpc.themes.themes_dir())
-    } catch (err) {
-      console.error("Failed to open themes folder:", err)
-    }
-  }
-
   return (
     <div className="flex flex-col gap-6 max-w-[500px]">
-      <ThemeGrid themes={builtins} active={theme} onSelect={setTheme} />
-
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-sm text-muted-foreground">Custom themes</h2>
-          <button
-            onClick={openThemesFolder}
-            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Open themes folder
-          </button>
-        </div>
-
-        {externals.length > 0 ? (
-          <ThemeGrid themes={externals} active={theme} onSelect={setTheme} />
-        ) : (
-          <p className="text-sm text-muted-foreground">
-            Drop a <code>.css</code> file into <code>~/.config/rencal/themes</code> to add your own.
-          </p>
-        )}
-      </div>
+      <ThemeGrid themes={descriptors} active={theme} onSelect={setTheme} />
     </div>
   )
 }

--- a/src/components/settings/themes/ThemesPage.tsx
+++ b/src/components/settings/themes/ThemesPage.tsx
@@ -1,21 +1,74 @@
+import { openPath } from "@tauri-apps/plugin-opener"
+
+import { rpc } from "@/rpc"
+
 import { useTheme } from "@/hooks/useTheme"
 import { cn } from "@/lib/utils"
 
 import { CheckIcon } from "@/icons/check"
-import { themes, type ThemeId } from "@/themes/manifest"
+import { useThemeRegistry } from "@/themes/ThemeRegistry"
+import type { ThemeDescriptor } from "@/themes/manifest"
 
 export function ThemesPage() {
   const { theme, setTheme } = useTheme()
+  const { descriptors } = useThemeRegistry()
+
+  const builtins = descriptors.filter((d) => d.source === "builtin")
+  const externals = descriptors.filter((d) => d.source === "external")
+
+  async function openThemesFolder() {
+    try {
+      await openPath(await rpc.themes.themes_dir())
+    } catch (err) {
+      console.error("Failed to open themes folder:", err)
+    }
+  }
 
   return (
-    <div className="grid grid-cols-2 gap-3 max-w-[500px]">
+    <div className="flex flex-col gap-6 max-w-[500px]">
+      <ThemeGrid themes={builtins} active={theme} onSelect={setTheme} />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-sm text-muted-foreground">Custom themes</h2>
+          <button
+            onClick={openThemesFolder}
+            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Open themes folder
+          </button>
+        </div>
+
+        {externals.length > 0 ? (
+          <ThemeGrid themes={externals} active={theme} onSelect={setTheme} />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Drop a <code>.css</code> file into <code>~/.config/rencal/themes</code> to add your own.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ThemeGrid({
+  themes,
+  active,
+  onSelect,
+}: {
+  themes: ThemeDescriptor[]
+  active: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
       {themes.map((t) => {
-        const isActive = theme === t.id
+        const isActive = active === t.id
 
         return (
           <button
             key={t.id}
-            onClick={() => setTheme(t.id as ThemeId)}
+            onClick={() => onSelect(t.id)}
             className={cn(
               "relative flex flex-col gap-2 p-3 rounded-md border-2 text-left transition-colors",
               isActive ? "border-primary" : "border-transparent hover:bg-secondary",

--- a/src/components/toolbar/SettingsButton.tsx
+++ b/src/components/toolbar/SettingsButton.tsx
@@ -10,11 +10,10 @@ import { isMacOS } from "@/lib/utils"
 
 import { SettingsIcon } from "@/icons/settings"
 import { getActiveAppearance } from "@/themes/appearance"
-import { THEME_IDS, type ThemeId } from "@/themes/manifest"
+import { THEME_IDS } from "@/themes/manifest"
 
-function activeThemeId(): ThemeId {
-  const id = document.body.dataset.theme
-  return (THEME_IDS as readonly string[]).includes(id ?? "") ? (id as ThemeId) : THEME_IDS[0]
+function activeThemeId(): string {
+  return document.body.dataset.theme || THEME_IDS[0]
 }
 
 export async function openSettingsWindow() {

--- a/src/global.css
+++ b/src/global.css
@@ -3,12 +3,9 @@
 
 @import "./animations.css";
 
-/* Themes */
-@import "./themes/ren.css";
-@import "./themes/classic.css";
-@import "./themes/catpuccin-latte.css";
-@import "./themes/tokyonight.css";
-@import "./themes/omarchy.css";
+/* Built-in themes (src/themes/*.css) are bundled and scoped by the
+   `rencal-themes` Vite plugin and imported as `virtual:rencal-themes.css`
+   in main.tsx, after this file so their [data-theme] rules win the cascade. */
 
 @font-face {
   font-family: "Geist Mono";

--- a/src/hooks/useOmarchyTheme.ts
+++ b/src/hooks/useOmarchyTheme.ts
@@ -88,6 +88,10 @@ function applyOmarchyColors(c: OmarchyColors) {
   // do this itself because the appearance is derived from these colors.
   if (document.body.dataset.theme === "omarchy") {
     void getCurrentWindow().setTheme(appearanceFromHex(c.background))
+    // Keep index.html's flash-prevention cache in step with the live OS theme.
+    try {
+      localStorage.setItem("themeBackground", c.background)
+    } catch {}
   }
 }
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -7,19 +7,22 @@ import { rpc } from "@/rpc"
 import { THEME_CHANGED } from "@/rpc/events"
 
 import { useLocalStorage } from "@/hooks/useLocalStorage"
-import { useOmarchyTheme } from "@/hooks/useOmarchyTheme"
 
+import { useThemeRegistry } from "@/themes/ThemeRegistry"
 import { getActiveAppearance } from "@/themes/appearance"
-import { THEME_IDS, type ThemeId } from "@/themes/manifest"
+import { THEME_IDS } from "@/themes/manifest"
 
-const themeSchema = z.enum(THEME_IDS)
-export type Theme = ThemeId
+// Theme id is a plain string: a built-in id or a user theme's `user:<slug>`.
+// An unknown id just renders the :root defaults, so no enum gate is needed.
+const themeSchema = z.string()
+export type Theme = string
+
+// index.html reads this to paint the right background before the CSS bundle loads.
+const BACKGROUND_CACHE_KEY = "themeBackground"
 
 function getDefaultTheme(): Theme {
   // Read default theme from index.html
-  const theme = document.body.dataset.defaultTheme
-  const parsed = themeSchema.safeParse(theme)
-  return parsed.success ? parsed.data : THEME_IDS[0]
+  return document.body.dataset.defaultTheme || THEME_IDS[0]
 }
 
 // Single mutator for theme. localStorage is a flash-prevention cache;
@@ -28,6 +31,7 @@ function getDefaultTheme(): Theme {
 // either store. On mount we reconcile from TOML (TOML wins on conflict).
 export function useTheme() {
   const [theme, setThemeLocal] = useLocalStorage("theme", themeSchema, getDefaultTheme())
+  const { descriptors } = useThemeRegistry()
   const themeRef = useRef(theme)
   themeRef.current = theme
 
@@ -40,7 +44,19 @@ export function useTheme() {
     void getCurrentWindow().setTheme(getActiveAppearance(theme))
   }, [theme])
 
-  useOmarchyTheme()
+  // Cache the resolved --background for index.html's flash-prevention. Deferred
+  // a frame so any runtime-injected user/omarchy styles are applied first.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      const bg = getComputedStyle(document.body).getPropertyValue("--background").trim()
+      if (bg) {
+        try {
+          localStorage.setItem(BACKGROUND_CACHE_KEY, bg)
+        } catch {}
+      }
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [theme])
 
   // Reconcile with TOML on mount; migrate cached value up if no file yet.
   useEffect(() => {
@@ -103,9 +119,13 @@ export function useTheme() {
       })
   }
 
+  // Cycle through every registered theme (built-in + user), in display order.
   const toggleTheme = () => {
-    const i = THEME_IDS.indexOf(theme)
-    setTheme(THEME_IDS[(i + 1) % THEME_IDS.length])
+    const ids = descriptors.map((d) => d.id)
+    if (ids.length === 0) return
+    const i = ids.indexOf(themeRef.current)
+    const next = ids[(i + 1) % ids.length]
+    if (next) setTheme(next)
   }
 
   return { theme, setTheme, toggleTheme }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -44,8 +44,8 @@ export function useTheme() {
     void getCurrentWindow().setTheme(getActiveAppearance(theme))
   }, [theme])
 
-  // Cache the resolved --background for index.html's flash-prevention. Deferred
-  // a frame so any runtime-injected user/omarchy styles are applied first.
+  // Cache the resolved --background for index.html's flash-prevention.
+  // Deferred by 1 frame so any runtime-injected user/omarchy styles are applied first.
   useEffect(() => {
     const raf = requestAnimationFrame(() => {
       const bg = getComputedStyle(document.body).getPropertyValue("--background").trim()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,17 @@
+// Global styles first, then the built-in themes (whose [data-theme] rules must
+// win over the :root defaults declared in global.css).
 import React from "react"
 import ReactDOM from "react-dom/client"
+
+import "@/global.css"
+import "virtual:rencal-themes.css"
 
 import { CalendarStateProvider } from "@/contexts/CalendarStateContext"
 import { SettingsProvider } from "@/contexts/SettingsContext"
 
 import { preloadCalendarData } from "@/lib/preload-data"
 
+import { ThemeProvider } from "@/themes/ThemeRegistry"
 import { AppWindow } from "@/windows/AppWindow"
 import { SettingsWindow } from "@/windows/SettingsWindow"
 
@@ -21,14 +27,16 @@ async function bootstrap() {
 
   ReactDOM.createRoot(rootEl).render(
     <React.StrictMode>
-      <SettingsProvider>
-        <CalendarStateProvider
-          initialCalendars={preload.initialCalendars}
-          initialDate={preload.initialDate}
-        >
-          {appWindow === "settings" ? <SettingsWindow /> : <AppWindow preload={preload} />}
-        </CalendarStateProvider>
-      </SettingsProvider>
+      <ThemeProvider>
+        <SettingsProvider>
+          <CalendarStateProvider
+            initialCalendars={preload.initialCalendars}
+            initialDate={preload.initialDate}
+          >
+            {appWindow === "settings" ? <SettingsWindow /> : <AppWindow preload={preload} />}
+          </CalendarStateProvider>
+        </SettingsProvider>
+      </ThemeProvider>
     </React.StrictMode>,
   )
 }

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -22,6 +22,20 @@ export type CredentialFieldInput = { id: string; value: string }
 
 export type EventAttendee = { name: string | null; email: string; response_status: ResponseStatus | null }
 
+export type ExternalTheme = { 
+/**
+ * Stable id, namespaced to avoid colliding with built-in themes.
+ */
+id: string; 
+/**
+ * Display name from an optional `@name` comment directive, else the filename.
+ */
+name: string; 
+/**
+ * Raw file contents (a bare declaration block, no selector).
+ */
+css: string }
+
 export type OmarchyColors = { background: string; foreground: string; accent: string; cursor: string | null; selection_foreground: string | null; selection_background: string | null; color0: string; color1: string; color2: string; color3: string; color4: string; color5: string; color6: string; color7: string; color8: string; color9: string; color10: string; color11: string; color12: string; color13: string; color14: string; color15: string }
 
 export type ProviderConnectInfo = { step: ProviderConnectStepKind; fields: ProviderField[]; instructions: string | null }
@@ -98,7 +112,7 @@ export type UpdateEventInput = { id: string; calendar_slug: string;
  */
 new_calendar_slug: string | null; summary: string; description: string | null; location: string | null; start: RpcEventTime; end: RpcEventTime; recurrence: RpcRecurrence | null; reminders: number[]; attendees: EventAttendee[] }
 
-const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}' }
+const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}', 'themes':'{"list_external":[],"themes_dir":[]}' }
 export type Router = { "caldir": {check_provider_connection: (providerName: string, account: string) => Promise<null>, 
 connect_provider: (providerName: string) => Promise<Calendar[]>, 
 connect_provider_with_credentials: (providerName: string, credentials: CredentialFieldInput[]) => Promise<Calendar[]>, 
@@ -134,7 +148,9 @@ set_auto_sync_enabled: (enabled: boolean) => Promise<null>,
 set_notifications_enabled: (enabled: boolean) => Promise<null>, 
 set_theme: (theme: string) => Promise<null>},
 "omarchy": {get_colors: () => Promise<OmarchyColors | null>},
-"platform": {needs_native_decorations: () => Promise<boolean>} };
+"platform": {needs_native_decorations: () => Promise<boolean>},
+"themes": {list_external: () => Promise<ExternalTheme[]>, 
+themes_dir: () => Promise<string>} };
 
 
 export const createTauRPCProxy = () => createProxy<Router>(ARGS_MAP)

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -22,19 +22,11 @@ export type CredentialFieldInput = { id: string; value: string }
 
 export type EventAttendee = { name: string | null; email: string; response_status: ResponseStatus | null }
 
-export type ExternalTheme = { 
+export type ExternalTheme = { id: string; 
 /**
- * Stable id, namespaced to avoid colliding with built-in themes.
+ * Uses `@name` (or filename as fallback)
  */
-id: string; 
-/**
- * Display name from an optional `@name` comment directive, else the filename.
- */
-name: string; 
-/**
- * Raw file contents (a bare declaration block, no selector).
- */
-css: string }
+name: string; css: string }
 
 export type OmarchyColors = { background: string; foreground: string; accent: string; cursor: string | null; selection_foreground: string | null; selection_background: string | null; color0: string; color1: string; color2: string; color3: string; color4: string; color5: string; color6: string; color7: string; color8: string; color9: string; color10: string; color11: string; color12: string; color13: string; color14: string; color15: string }
 

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -112,7 +112,7 @@ export type UpdateEventInput = { id: string; calendar_slug: string;
  */
 new_calendar_slug: string | null; summary: string; description: string | null; location: string | null; start: RpcEventTime; end: RpcEventTime; recurrence: RpcRecurrence | null; reminders: number[]; attendees: EventAttendee[] }
 
-const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}', 'themes':'{"list_external":[],"themes_dir":[]}' }
+const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}', 'themes':'{"list_external":[]}' }
 export type Router = { "caldir": {check_provider_connection: (providerName: string, account: string) => Promise<null>, 
 connect_provider: (providerName: string) => Promise<Calendar[]>, 
 connect_provider_with_credentials: (providerName: string, credentials: CredentialFieldInput[]) => Promise<Calendar[]>, 
@@ -149,8 +149,7 @@ set_notifications_enabled: (enabled: boolean) => Promise<null>,
 set_theme: (theme: string) => Promise<null>},
 "omarchy": {get_colors: () => Promise<OmarchyColors | null>},
 "platform": {needs_native_decorations: () => Promise<boolean>},
-"themes": {list_external: () => Promise<ExternalTheme[]>, 
-themes_dir: () => Promise<string>} };
+"themes": {list_external: () => Promise<ExternalTheme[]>} };
 
 
 export const createTauRPCProxy = () => createProxy<Router>(ARGS_MAP)

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -1,39 +1,43 @@
 # Themes
 
-Themes live in `src/themes/` and override a small set of primitive CSS variables. Themes are scoped by `[data-theme="<id>"]` so they apply both to the whole app (when set on `<body>`) and to any opt-in subtree (e.g. the theme preview tile in settings). The defaults (the "ren" look) live in a `:root, [data-theme="ren"]` block in `src/global.css`; a theme's job is to change only what makes it distinct.
+A theme is a **bare block of CSS custom-property declarations** — no selector:
 
-Most tokens are **derived** from a handful of primitives via `color-mix()` (declared in the `body { ... }` block in `src/global.css`). In practice, setting `--background`, `--foreground`, `--hover-tint`, and `--primary` gets you most of a theme — hover, card, divider, secondary, etc. all fall out automatically. See `tokyonight.css` for a minimal example.
+```css
+--background: #0f0f0f;
+--foreground: #eaeaea;
+--hover-tint: #ffffff;
+--primary: #7c3aed;
+--highlight: #7c3aed;
+```
 
-## Adding a theme
+The `[data-theme="<id>"]` scope that lets themes coexist (so the app picks one on `<body>` and the settings preview tiles can render others) is added **for you**:
 
-1. **Create the CSS file**: `src/themes/mytheme.css`.
+- **Built-in themes** (`src/themes/*.css`) are wrapped at build time by the `rencal-themes` Vite plugin (`vite-plugin-rencal-themes.ts`) and bundled as `virtual:rencal-themes.css` (imported in `src/main.tsx`).
+- **User themes** (`~/.config/rencal/themes/*.css`) are read by the Rust watcher (`src-tauri/src/external_themes.rs`) and wrapped + injected at runtime by `src/themes/ThemeRegistry.tsx`.
 
-   ```css
-   [data-theme="mytheme"] {
-     --background: #0f0f0f;
-     --foreground: #eaeaea;
-     --hover-tint: #ffffff;
-     --primary: #7c3aed;
-     --highlight: #7c3aed;
-   }
-   ```
+The defaults (the "ren" look) live in a `:root, [data-theme="ren"]` block in `src/global.css`; a theme only changes what makes it distinct. Most tokens are **derived** from a handful of primitives via `color-mix()` (the `body { ... }` block in `src/global.css`). In practice, setting `--background`, `--foreground`, `--hover-tint`, and `--primary` gets you most of a theme — hover, card, divider, secondary, etc. fall out automatically. See `tokyonight.css` for a minimal example.
 
-2. **Import it** from `src/global.css` (add next to the other theme imports).
+## Adding a built-in theme
 
-3. **Register it** in `src/themes/manifest.ts`:
+1. **Create the file**: `src/themes/mytheme.css` — a bare declaration block (see above). The filename is the theme id.
+2. **Register it** in `src/themes/manifest.ts`:
 
    ```ts
-   { id: "mytheme", name: "My Theme" },
+   { id: "mytheme", name: "My Theme", appearance: "dark" },
    ```
 
-4. **Add a flash-prevention rule** in `index.html` pointing at the theme's background color. This runs before the CSS bundle loads, so it has to live inline:
+That's it — no `@import`, no `index.html` edit. The Vite plugin discovers the file by glob, `useTheme` picks it up, and Ctrl/Cmd+Shift+T cycles through every registered theme. (Flash-prevention is automatic: `useTheme` caches the active theme's `--background` and `index.html` repaints it on next launch.)
 
-   ```html
-   body[data-theme="mytheme"], body:not([data-theme])[data-default-theme="mytheme"] {
-   background-color: #0f0f0f; }
-   ```
+## User themes
 
-That's it. `useTheme` will pick up the new theme automatically, and Ctrl/Cmd+Shift+T cycles through all registered themes.
+End users add themes without touching the source. Drop a `.css` file into `~/.config/rencal/themes/` and it appears under **Settings → Themes → Custom themes**:
+
+- Same bare-declaration format as built-ins — **no selector**.
+- The filename becomes the display name; override it with a leading `/* @name My Theme */` comment.
+- Edits/additions/removals apply live (a Rust file-watcher re-emits the list).
+- Ids are namespaced `user:<slug>` so they never collide with built-ins.
+
+Most user themes only set variables, which is plain scoped CSS. If a theme adds **custom selectors** (the escape hatch below), they're scoped via native CSS nesting — supported in renCal's webview, but note it's the one feature a bare variable-only theme doesn't depend on.
 
 ## Primitives
 
@@ -116,6 +120,17 @@ If Omarchy isn't installed (or `colors.toml` is missing), no rule is written and
 
 ## Escape hatch: custom CSS rules
 
-If primitive overrides aren't enough, theme files can include arbitrary CSS rules. Scope them with `[data-theme="yourtheme"]` (or use CSS nesting inside that selector) so they don't leak to other themes.
+If primitive overrides aren't enough, a theme file can include arbitrary CSS rules alongside its declarations. Write them as **nested selectors** — the file is already wrapped in the theme's `[data-theme="<id>"]` scope, so they won't leak to other themes:
+
+```css
+--primary: #7c3aed;
+
+.some-component {
+  /* automatically becomes [data-theme="<id>"] .some-component */
+  border-radius: 0;
+}
+```
+
+(Built-in themes get this flattened at build time; user themes rely on the webview's native CSS nesting.)
 
 Prefer primitives first — the derivation chain covers most visual-identity needs. You can also override a derived token directly (e.g., set `--divider` explicitly in `classic.css`) when the computed value isn't right for the theme. Reach for custom rules only when a theme needs to reshape a specific component beyond what the contract exposes.

--- a/src/themes/ThemeRegistry.tsx
+++ b/src/themes/ThemeRegistry.tsx
@@ -1,0 +1,104 @@
+import { listen } from "@tauri-apps/api/event"
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
+
+import { rpc } from "@/rpc"
+import type { ExternalTheme } from "@/rpc/bindings"
+
+import { useOmarchyTheme } from "@/hooks/useOmarchyTheme"
+
+import { BUILTIN_DESCRIPTORS, type ThemeDescriptor } from "@/themes/manifest"
+
+const EXTERNAL_THEMES_CHANGED = "external-themes-changed"
+const STYLE_ATTR = "data-external-theme"
+
+// User themes are authored as bare declaration blocks; we add the
+// `[data-theme="<id>"]` scope here (the same wrap the build-time plugin applies
+// to built-in themes), keeping every injected theme isolated so the settings
+// preview tiles can render inactive themes side by side.
+function applyExternalThemes(themes: ExternalTheme[]) {
+  const present = new Set(themes.map((t) => t.id))
+
+  for (const theme of themes) {
+    const selector = `style[${STYLE_ATTR}="${CSS.escape(theme.id)}"]`
+    let el = document.head.querySelector<HTMLStyleElement>(selector)
+    if (!el) {
+      el = document.createElement("style")
+      el.setAttribute(STYLE_ATTR, theme.id)
+      document.head.appendChild(el)
+    }
+    const next = `[data-theme="${theme.id}"] {\n${theme.css}\n}`
+    if (el.textContent !== next) el.textContent = next
+  }
+
+  // Drop styles for themes whose files were removed.
+  for (const el of document.head.querySelectorAll<HTMLStyleElement>(`style[${STYLE_ATTR}]`)) {
+    const id = el.getAttribute(STYLE_ATTR)
+    if (id && !present.has(id)) el.remove()
+  }
+}
+
+type ThemeRegistry = {
+  descriptors: ThemeDescriptor[]
+  externalThemes: ExternalTheme[]
+}
+
+const ThemeRegistryContext = createContext<ThemeRegistry | null>(null)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [externalThemes, setExternalThemes] = useState<ExternalTheme[]>([])
+
+  // Fetch + inject user themes, then keep them in sync with the on-disk folder.
+  useEffect(() => {
+    let cancelled = false
+
+    const update = (themes: ExternalTheme[]) => {
+      setExternalThemes(themes)
+      applyExternalThemes(themes)
+    }
+
+    void rpc.themes.list_external().then((themes) => {
+      if (!cancelled) update(themes)
+    })
+
+    const unlistenPromise = listen<ExternalTheme[]>(EXTERNAL_THEMES_CHANGED, (event) => {
+      update(event.payload)
+    })
+
+    return () => {
+      cancelled = true
+      void unlistenPromise.then((fn) => fn())
+    }
+  }, [])
+
+  // Omarchy's runtime palette injection lives here so it runs once per window,
+  // not once per useTheme() call.
+  useOmarchyTheme()
+
+  const descriptors = useMemo<ThemeDescriptor[]>(
+    () => [
+      ...BUILTIN_DESCRIPTORS,
+      ...externalThemes.map(
+        (t): ThemeDescriptor => ({
+          id: t.id,
+          name: t.name,
+          appearance: null,
+          source: "external",
+        }),
+      ),
+    ],
+    [externalThemes],
+  )
+
+  const value = useMemo<ThemeRegistry>(
+    () => ({ descriptors, externalThemes }),
+    [descriptors, externalThemes],
+  )
+
+  return <ThemeRegistryContext.Provider value={value}>{children}</ThemeRegistryContext.Provider>
+}
+
+export function useThemeRegistry(): ThemeRegistry {
+  const ctx = useContext(ThemeRegistryContext)
+  if (!ctx) throw new Error("useThemeRegistry must be used within a ThemeProvider")
+  return ctx
+}

--- a/src/themes/appearance.ts
+++ b/src/themes/appearance.ts
@@ -1,4 +1,4 @@
-import { type Appearance, type ThemeId, getDeclaredAppearance } from "./manifest"
+import { type Appearance, getDeclaredAppearance } from "./manifest"
 
 function hexLuminance(hex: string): number {
   const h = hex.replace("#", "").trim()
@@ -23,6 +23,8 @@ export function appearanceFromComputedBackground(): Appearance {
   return "dark"
 }
 
-export function getActiveAppearance(id: ThemeId): Appearance {
+// Built-in themes declare their appearance; user/omarchy themes derive it from
+// the live --background once their styles are applied.
+export function getActiveAppearance(id: string): Appearance {
   return getDeclaredAppearance(id) ?? appearanceFromComputedBackground()
 }

--- a/src/themes/catpuccin-latte.css
+++ b/src/themes/catpuccin-latte.css
@@ -1,22 +1,18 @@
-:root {
-  /* Catpuccin Latte palette */
-  --theme-base: #eff1f5;
-  --theme-surface-0: #ccd0da;
-  --theme-text: #4c4f69;
-  --theme-subtext-0: #6c6f85;
-  --theme-lavender: #7287fd;
-  --theme-blue: #1e66f5;
-}
+/* Catpuccin Latte palette (scoped to this theme, not leaked to :root) */
+--theme-base: #eff1f5;
+--theme-surface-0: #ccd0da;
+--theme-text: #4c4f69;
+--theme-subtext-0: #6c6f85;
+--theme-lavender: #7287fd;
+--theme-blue: #1e66f5;
 
-[data-theme="catpuccin-latte"] {
-  --background: var(--theme-base);
-  --foreground: var(--theme-text);
-  --muted: var(--theme-subtext-0);
-  --divider: var(--theme-surface-0);
+--background: var(--theme-base);
+--foreground: var(--theme-text);
+--muted: var(--theme-subtext-0);
+--divider: var(--theme-surface-0);
 
-  --hover-tint: #484f7f;
-  --hover-mix: 10%;
+--hover-tint: #484f7f;
+--hover-mix: 10%;
 
-  --primary: var(--theme-lavender);
-  --today: var(--theme-blue);
-}
+--primary: var(--theme-lavender);
+--today: var(--theme-blue);

--- a/src/themes/classic.css
+++ b/src/themes/classic.css
@@ -1,26 +1,24 @@
-[data-theme="classic"] {
-  --background: #1a1b26;
-  --font-heading: var(--sans);
-  --font-button: var(--sans);
-  --font-numerical: var(--sans);
+--background: #1a1b26;
+--font-heading: var(--sans);
+--font-button: var(--sans);
+--font-numerical: var(--sans);
 
-  --font-heading-transform: normal;
-  --font-button-transform: normal;
+--font-heading-transform: normal;
+--font-button-transform: normal;
 
-  --divider: #40404f;
-  --border-button: #363643;
+--divider: #40404f;
+--border-button: #363643;
 
-  --highlight: #ff2f00; /* year */
+--highlight: #ff2f00; /* year */
 
-  --tab-gap: 6px;
-  --tab-list-shadow: none;
+--tab-gap: 6px;
+--tab-list-shadow: none;
 
-  --hover-tint: #979bc8;
-  --hover-mix: 10%;
+--hover-tint: #979bc8;
+--hover-mix: 10%;
 
-  --radius-base: 0.6rem;
-  --radius-circle: calc(infinity * 1px);
+--radius-base: 0.6rem;
+--radius-circle: calc(infinity * 1px);
 
-  --primary: #0094c6;
-  --primary-foreground: white;
-}
+--primary: #0094c6;
+--primary-foreground: white;

--- a/src/themes/manifest.ts
+++ b/src/themes/manifest.ts
@@ -14,6 +14,28 @@ export type ThemeId = (typeof themes)[number]["id"]
 
 export const THEME_IDS = themes.map((t) => t.id) as [ThemeId, ...ThemeId[]]
 
-export function getDeclaredAppearance(id: ThemeId): Appearance | null {
-  return themes.find((t) => t.id === id)?.appearance ?? null
+// Built-in themes ship a declared appearance; user themes don't, so the active
+// theme is identified by a plain string (built-in id or `user:<slug>`) and an
+// unknown id simply falls through to the :root defaults.
+export type ThemeSource = "builtin" | "external"
+
+export type ThemeDescriptor = {
+  id: string
+  name: string
+  appearance: Appearance | null
+  source: ThemeSource
+}
+
+export const BUILTIN_DESCRIPTORS: ThemeDescriptor[] = themes.map((t) => ({
+  id: t.id,
+  name: t.name,
+  appearance: t.appearance,
+  source: "builtin",
+}))
+
+export function getDeclaredAppearance(id: string): Appearance | null {
+  return (
+    (themes as readonly { id: string; appearance: Appearance | null }[]).find((t) => t.id === id)
+      ?.appearance ?? null
+  )
 }

--- a/src/themes/manifest.ts
+++ b/src/themes/manifest.ts
@@ -14,9 +14,6 @@ export type ThemeId = (typeof themes)[number]["id"]
 
 export const THEME_IDS = themes.map((t) => t.id) as [ThemeId, ...ThemeId[]]
 
-// Built-in themes ship a declared appearance; user themes don't, so the active
-// theme is identified by a plain string (built-in id or `user:<slug>`) and an
-// unknown id simply falls through to the :root defaults.
 export type ThemeSource = "builtin" | "external"
 
 export type ThemeDescriptor = {

--- a/src/themes/omarchy.css
+++ b/src/themes/omarchy.css
@@ -6,12 +6,10 @@
    preview tile or if selected manually) — these mirror the Tokyo Night
    palette. When Omarchy is installed, the dynamically-injected rule comes
    later in source order and overrides these. */
-[data-theme="omarchy"] {
-  --background: #1a1b26;
-  --foreground: #c0caf5;
-  --muted: #9aa5ce;
-  --highlight: #f7768e;
-  --today: #7dcfff;
-  --hover-tint: #a7b7ff;
-  --primary: #7aa2f7;
-}
+--background: #1a1b26;
+--foreground: #c0caf5;
+--muted: #9aa5ce;
+--highlight: #f7768e;
+--today: #7dcfff;
+--hover-tint: #a7b7ff;
+--primary: #7aa2f7;

--- a/src/themes/tokyonight.css
+++ b/src/themes/tokyonight.css
@@ -1,9 +1,7 @@
-[data-theme="tokyonight"] {
-  --background: #1a1b26;
-  --foreground: #c0caf5;
-  --muted: #9aa5ce;
-  --highlight: #f7768e;
-  --today: #7dcfff;
-  --hover-tint: #a7b7ff;
-  --primary: #7aa2f7;
-}
+--background: #1a1b26;
+--foreground: #c0caf5;
+--muted: #9aa5ce;
+--highlight: #f7768e;
+--today: #7dcfff;
+--hover-tint: #a7b7ff;
+--primary: #7aa2f7;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+// Built-in themes bundled + scoped by the `rencal-themes` Vite plugin.
+declare module "virtual:rencal-themes.css"

--- a/src/windows/AppWindow.tsx
+++ b/src/windows/AppWindow.tsx
@@ -1,7 +1,5 @@
 import { Toaster } from "sonner"
 
-import "@/global.css"
-
 import { PopoverEditEvent } from "@/components/event-parts/PopoverEditEvent"
 import { PopoverNewEvent } from "@/components/event-parts/PopoverNewEvent"
 import { SheetEvent } from "@/components/event-parts/SheetInfo"

--- a/vite-plugin-rencal-themes.ts
+++ b/vite-plugin-rencal-themes.ts
@@ -3,11 +3,8 @@ import path from "node:path"
 import type { Plugin } from "vite"
 
 // Bundles the built-in theme files (src/themes/*.css) into a single virtual CSS
-// module, wrapping each in its `[data-theme="<filename>"] { … }` selector. This
-// lets theme files be authored as bare declaration blocks (no selector) — the
-// same format user themes use — while staying in the CSS bundle (no flash).
-//
-// The id ends in `.css` so Vite routes the output through its CSS pipeline.
+// module, wrapping each in its [data-theme] selector.
+// Id ends in `.css` so Vite routes the output through its CSS pipeline.
 const VIRTUAL_ID = "virtual:rencal-themes.css"
 const RESOLVED_ID = "\0virtual:rencal-themes.css"
 

--- a/vite-plugin-rencal-themes.ts
+++ b/vite-plugin-rencal-themes.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs"
+import path from "node:path"
+import type { Plugin } from "vite"
+
+// Bundles the built-in theme files (src/themes/*.css) into a single virtual CSS
+// module, wrapping each in its `[data-theme="<filename>"] { … }` selector. This
+// lets theme files be authored as bare declaration blocks (no selector) — the
+// same format user themes use — while staying in the CSS bundle (no flash).
+//
+// The id ends in `.css` so Vite routes the output through its CSS pipeline.
+const VIRTUAL_ID = "virtual:rencal-themes.css"
+const RESOLVED_ID = "\0virtual:rencal-themes.css"
+
+export function rencalThemes(themesDir = path.resolve(__dirname, "src/themes")): Plugin {
+  function bundle(): string {
+    return fs
+      .readdirSync(themesDir)
+      .filter((file) => file.endsWith(".css"))
+      .sort()
+      .map((file) => {
+        const id = path.basename(file, ".css")
+        const css = fs.readFileSync(path.join(themesDir, file), "utf8")
+        return `[data-theme="${id}"] {\n${css}\n}`
+      })
+      .join("\n\n")
+  }
+
+  return {
+    name: "rencal-themes",
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID
+    },
+    load(id) {
+      if (id === RESOLVED_ID) return bundle()
+    },
+    configureServer(server) {
+      // Re-bundle + reload when a built-in theme file changes in dev.
+      server.watcher.add(themesDir)
+      const onChange = (file: string) => {
+        if (path.dirname(file) !== themesDir || !file.endsWith(".css")) return
+        const mod = server.moduleGraph.getModuleById(RESOLVED_ID)
+        if (mod) server.moduleGraph.invalidateModule(mod)
+        server.ws.send({ type: "full-reload" })
+      }
+      server.watcher.on("add", onChange)
+      server.watcher.on("change", onChange)
+      server.watcher.on("unlink", onChange)
+    },
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,15 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite"
+import react from "@vitejs/plugin-react"
+import path from "path"
+import { defineConfig } from "vite"
 
-import path from "path";
-import tailwindcss from "@tailwindcss/vite";
+import { rencalThemes } from "./vite-plugin-rencal-themes"
 
-const host = process.env.TAURI_DEV_HOST;
+const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), rencalThemes()],
 
   resolve: {
     alias: {
@@ -37,4 +38,4 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
-}));
+}))

--- a/website/src/content/docs/docs/themes.md
+++ b/website/src/content/docs/docs/themes.md
@@ -10,3 +10,19 @@ Change renCal's theme from the settings, or press <kbd>Ctrl</kbd><kbd>Shift</kbd
 The "Omarchy" theme updates automatically when your system theme changes:
 
 <video src="/docs/omarchy-theme.mp4" autoplay loop muted playsinline></video>
+
+## Add your own theme
+
+Create a `.css` file in `~/.config/rencal/themes/` to add a custom theme. renCal watches this folder, so new files, edits, and removals show up automatically in the settings.
+
+```css
+/* @name My Theme */
+--background: #0f0f0f;
+--foreground: #eaeaea;
+--muted: rgba(234, 234, 234, 0.6);
+--primary: #7c3aed;
+--highlight: #7c3aed;
+--hover-tint: #ffffff;
+```
+
+Most themes only need to set `--background`, `--foreground`, `--muted`, `--primary`, `--highlight`, and `--hover-tint`. renCal derives surfaces, dividers, hover states, and other colors from those values.


### PR DESCRIPTION
This lets users add their own CSS files to `~/.config/rencal/themes/` to customize the look and feel of renCal.

<img width="1476" height="1092" alt="image" src="https://github.com/user-attachments/assets/2b4ec647-c80e-4d9e-bd21-fd8f1b6b8d16" />
