### PR TITLE
Fix single-instance leak on Linux

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,13 +112,8 @@ pub async fn run() {
         None => return, // existing instance was signaled to focus; we exit.
     };
 
-    // Take the accept-listener out of the guard so it can be moved into the
-    // setup closure, while `instance_guard` itself stays on this stack frame
-    // for the whole process lifetime. The guard unlinks the socket file on
-    // Drop, so it must outlive the app: if it were moved into `setup`, Tauri
-    // would drop it once setup returns, unlink the live socket, and every
-    // later launch would fail to connect and become its own resident
-    // instance — the multi-process leak we're avoiding.
+    // Keep the guard on this frame for the whole process; dropping it early
+    // removes the socket and breaks single-instance detection.
     #[cfg(target_os = "linux")]
     let instance_listener = instance_guard.take_listener();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,16 @@ pub async fn run() {
         None => return, // existing instance was signaled to focus; we exit.
     };
 
+    // Take the accept-listener out of the guard so it can be moved into the
+    // setup closure, while `instance_guard` itself stays on this stack frame
+    // for the whole process lifetime. The guard unlinks the socket file on
+    // Drop, so it must outlive the app: if it were moved into `setup`, Tauri
+    // would drop it once setup returns, unlink the live socket, and every
+    // later launch would fail to connect and become its own resident
+    // instance — the multi-process leak we're avoiding.
+    #[cfg(target_os = "linux")]
+    let instance_listener = instance_guard.take_listener();
+
     let router = create_router();
 
     let builder = tauri::Builder::default();
@@ -158,14 +168,16 @@ pub async fn run() {
             #[cfg(target_os = "linux")]
             {
                 linux_reminders::enable_notifierd_if_needed();
-                let app_handle = app.handle().clone();
-                single_instance::spawn_listener(&mut instance_guard, move || {
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        let _ = window.unminimize();
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
-                });
+                if let Some(listener) = instance_listener {
+                    let app_handle = app.handle().clone();
+                    single_instance::spawn_listener(listener, move || {
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.unminimize();
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    });
+                }
             }
 
             spawn_reminder_loop_if_needed(app);

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -35,6 +35,22 @@ impl Drop for InstanceGuard {
     }
 }
 
+impl InstanceGuard {
+    /// Take ownership of the accept-listener so it can be moved into the
+    /// background accept thread (see [`spawn_listener`]).
+    ///
+    /// The guard itself — which holds the socket *path* and unlinks it on
+    /// `Drop` — must be kept alive by the caller for the whole process
+    /// lifetime. Dropping it early unlinks a still-listening socket and
+    /// orphans it: the file disappears while the listener lives on, so every
+    /// later launch fails to `connect`, assumes it is the first instance, and
+    /// spawns yet another resident process. That is precisely the leak this
+    /// type exists to prevent, so never let the guard drop before exit.
+    pub fn take_listener(&mut self) -> Option<UnixListener> {
+        self.listener.take()
+    }
+}
+
 fn socket_path() -> PathBuf {
     if let Some(runtime) = dirs::runtime_dir() {
         // XDG_RUNTIME_DIR is already per-user (mode 0700, owned by the user),
@@ -80,15 +96,14 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
 }
 
 /// Spawn a thread that listens for `focus\n` messages and invokes `on_focus`
-/// for each. Consumes the listener out of the guard; the guard still holds
-/// the path so cleanup on Drop still works.
-pub fn spawn_listener<F>(guard: &mut InstanceGuard, on_focus: F)
+/// for each. Takes ownership of the `listener` (extracted from the guard via
+/// [`InstanceGuard::take_listener`]) and holds it for the process lifetime;
+/// the guard stays with the caller so the socket file is unlinked only at
+/// real shutdown.
+pub fn spawn_listener<F>(listener: UnixListener, on_focus: F)
 where
     F: Fn() + Send + 'static,
 {
-    let Some(listener) = guard.listener.take() else {
-        return;
-    };
     std::thread::spawn(move || {
         for incoming in listener.incoming() {
             let Ok(mut stream) = incoming else { continue };

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -36,16 +36,8 @@ impl Drop for InstanceGuard {
 }
 
 impl InstanceGuard {
-    /// Take ownership of the accept-listener so it can be moved into the
-    /// background accept thread (see [`spawn_listener`]).
-    ///
-    /// The guard itself — which holds the socket *path* and unlinks it on
-    /// `Drop` — must be kept alive by the caller for the whole process
-    /// lifetime. Dropping it early unlinks a still-listening socket and
-    /// orphans it: the file disappears while the listener lives on, so every
-    /// later launch fails to `connect`, assumes it is the first instance, and
-    /// spawns yet another resident process. That is precisely the leak this
-    /// type exists to prevent, so never let the guard drop before exit.
+    /// Take the listener for the accept thread. The caller keeps the guard so
+    /// the socket survives for the whole process (see [`spawn_listener`]).
     pub fn take_listener(&mut self) -> Option<UnixListener> {
         self.listener.take()
     }
@@ -95,11 +87,7 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
     }
 }
 
-/// Spawn a thread that listens for `focus\n` messages and invokes `on_focus`
-/// for each. Takes ownership of the `listener` (extracted from the guard via
-/// [`InstanceGuard::take_listener`]) and holds it for the process lifetime;
-/// the guard stays with the caller so the socket file is unlinked only at
-/// real shutdown.
+/// Spawn a thread that listens for `focus\n` messages and invokes `on_focus` for each.
 pub fn spawn_listener<F>(listener: UnixListener, on_focus: F)
 where
     F: Fn() + Send + 'static,


### PR DESCRIPTION
Noticed that every rencal launch would spawn a new webkit process, hogging lots of RAM and slowing down the system.

Turns out our single-instance guard was being dropped right after startup: every launch assumed it was the first one, instead of focusing the existing window.

Keeping the guard alive for the whole process lifetime fixes it.