### PR TITLE
Fix ugly time inputs when checking "all-day"

### DIFF
--- a/src/components/event-parts/ComposeEvent.tsx
+++ b/src/components/event-parts/ComposeEvent.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { useCalendars } from "@/contexts/CalendarStateContext"
 import { useEventDraft } from "@/contexts/EventDraftContext"
 
+import { useLastTimedRange } from "@/hooks/useLastTimedRange"
 import {
   addMinutes,
   DEFAULT_DURATION_MINS,
@@ -30,11 +31,18 @@ export const ComposeEventInner = ({
   onTabOut?: () => void
 }) => {
   const { calendars } = useCalendars()
-  const { draftEvent, setDraftEvent, draftReminders, setDraftReminders, createDraftEvent } =
-    useEventDraft()
+  const {
+    draftEvent,
+    setDraftEvent,
+    draftReminders,
+    setDraftReminders,
+    createDraftEvent,
+    draftPopoverOpen,
+  } = useEventDraft()
 
   const { summary, description, start, end, location, calendarId, recurrence } = draftEvent
   const allDay = isAllDay(start)
+  const lastTimedRange = useLastTimedRange(start, end, draftPopoverOpen)
 
   const recurrenceRRule = recurrence ? rrulestr(recurrence.rrule) : null
 
@@ -77,8 +85,8 @@ export const ComposeEventInner = ({
               const timedStart = isAllDay(start) ? toTimedAtStartOfDay(start) : start
               setDraftEvent({
                 ...draftEvent,
-                start: timedStart,
-                end: addMinutes(timedStart, DEFAULT_DURATION_MINS),
+                start: lastTimedRange?.start ?? timedStart,
+                end: lastTimedRange?.end ?? addMinutes(timedStart, DEFAULT_DURATION_MINS),
               })
             }
           }}

--- a/src/components/event-parts/EditEvent.tsx
+++ b/src/components/event-parts/EditEvent.tsx
@@ -191,7 +191,6 @@ export const EditEvent = ({
             )
           }
         }}
-        showTime={!all_day}
         location={location}
         onLocationChange={(newLocation) => {
           setDirtyEvent({ ...dirtyEvent, location: newLocation || null })

--- a/src/components/event-parts/EditEvent.tsx
+++ b/src/components/event-parts/EditEvent.tsx
@@ -20,6 +20,7 @@ import { useCalendars } from "@/contexts/CalendarStateContext"
 import { useSync } from "@/contexts/SyncContext"
 
 import { useDeleteEvent } from "@/hooks/useDeleteEvent"
+import { useLastTimedRange } from "@/hooks/useLastTimedRange"
 import { withDates, type CalendarEvent } from "@/lib/cal-events"
 import {
   addMinutes,
@@ -127,6 +128,12 @@ export const EditEvent = ({
     setDirtyEvent({ ...dirtyEvent, reminders: dirtyEvent.reminders.filter((m) => m !== mins) })
   }
 
+  const lastTimedRange = useLastTimedRange(
+    dirtyEvent?.start ?? null,
+    dirtyEvent?.end ?? null,
+    event?.id,
+  )
+
   if (!dirtyEvent) return null
 
   const { summary, description, start, end, location, calendar_slug, recurrence } = dirtyEvent
@@ -187,7 +194,11 @@ export const EditEvent = ({
           } else {
             const timedStart = isAllDay(start) ? toTimedAtStartOfDay(start) : start
             setDirtyEvent(
-              withDates(dirtyEvent, timedStart, addMinutes(timedStart, DEFAULT_DURATION_MINS)),
+              withDates(
+                dirtyEvent,
+                lastTimedRange?.start ?? timedStart,
+                lastTimedRange?.end ?? addMinutes(timedStart, DEFAULT_DURATION_MINS),
+              ),
             )
           }
         }}

--- a/src/components/event-parts/inputs/DateTimeSelect.tsx
+++ b/src/components/event-parts/inputs/DateTimeSelect.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react"
+
 import { DatePicker } from "@/components/ui/date-picker"
 import { InputGroupAddon } from "@/components/ui/input-group"
 
@@ -41,6 +43,13 @@ export const DateTimeSelect = ({
   onChange: (range: DateTimeRange) => void
 }) => {
   const allDay = isAllDay(start)
+  const lastTimedRange = useRef<DateTimeRange | null>(null)
+
+  if (!allDay) {
+    lastTimedRange.current = { start, end }
+  }
+
+  const visibleTimeRange = allDay ? (lastTimedRange.current ?? { start, end }) : { start, end }
 
   const handleStartTime = (hour: number, minute: number) =>
     onChange(withRangeStartWallclockTime({ start, end }, hour, minute))
@@ -62,8 +71,8 @@ export const DateTimeSelect = ({
     <div className="flex flex-col gap-1">
       {showTime && (
         <TimeSelect
-          start={start}
-          end={end}
+          start={visibleTimeRange.start}
+          end={visibleTimeRange.end}
           allDay={allDay}
           readOnly={readOnly}
           onChangeStartTime={handleStartTime}

--- a/src/components/event-parts/inputs/DateTimeSelect.tsx
+++ b/src/components/event-parts/inputs/DateTimeSelect.tsx
@@ -1,8 +1,7 @@
-import { useRef } from "react"
-
 import { DatePicker } from "@/components/ui/date-picker"
 import { InputGroupAddon } from "@/components/ui/input-group"
 
+import { useLastTimedRange } from "@/hooks/useLastTimedRange"
 import {
   dateInEventZone,
   displayEndDate,
@@ -43,13 +42,8 @@ export const DateTimeSelect = ({
   onChange: (range: DateTimeRange) => void
 }) => {
   const allDay = isAllDay(start)
-  const lastTimedRange = useRef<DateTimeRange | null>(null)
-
-  if (!allDay) {
-    lastTimedRange.current = { start, end }
-  }
-
-  const visibleTimeRange = allDay ? (lastTimedRange.current ?? { start, end }) : { start, end }
+  const lastTimedRange = useLastTimedRange(start, end)
+  const visibleTimeRange = allDay ? (lastTimedRange ?? { start, end }) : { start, end }
 
   const handleStartTime = (hour: number, minute: number) =>
     onChange(withRangeStartWallclockTime({ start, end }, hour, minute))

--- a/src/hooks/useLastTimedRange.ts
+++ b/src/hooks/useLastTimedRange.ts
@@ -1,0 +1,23 @@
+import { useRef } from "react"
+
+import { isAllDay, type EventTime, type EventTimeRange } from "@/lib/event-time"
+
+export function useLastTimedRange(
+  start: EventTime | null,
+  end: EventTime | null,
+  resetKey?: unknown,
+): EventTimeRange | null {
+  const resetKeyRef = useRef(resetKey)
+  const lastTimedRangeRef = useRef<EventTimeRange | null>(null)
+
+  if (!Object.is(resetKeyRef.current, resetKey)) {
+    resetKeyRef.current = resetKey
+    lastTimedRangeRef.current = null
+  }
+
+  if (start && end && !isAllDay(start)) {
+    lastTimedRangeRef.current = { start, end }
+  }
+
+  return lastTimedRangeRef.current
+}


### PR DESCRIPTION
The time was completely hidden, instead of the expected 50% opacity

**Before:**

<img width="578" height="438" alt="screenshot-2026-06-29_07-54-32" src="https://github.com/user-attachments/assets/b42842dd-f499-47bf-8c3e-b52884d258ab" />

**After:**

<img width="584" height="442" alt="image" src="https://github.com/user-attachments/assets/f3cde56b-4dde-4761-ad37-835573f07913" />

