### PR TITLE
Add new "Releases" page to website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     paths: [website/**]
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
@@ -37,6 +39,8 @@ jobs:
       - name: Build
         run: pnpm build
         working-directory: website
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: cloudflare/wrangler-action@v3
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,9 @@ Provider credential field IDs come from the caldir provider binaries.
 - Notifications: `docs/notifications.md`, `src-tauri/reminder-core/`
 - Themes: `src/themes/README.md`, `src/themes/manifest.ts`, `src/global.css`
 - Omarchy theme: `src/hooks/useOmarchyTheme.ts`, `src/themes/omarchy.css`
+
+## Website rules
+
+- `website` is a standalone Astro project (Tailwind v4 + Starlight) with its own `package.json` / `pnpm-lock.yaml`; CI builds it with `pnpm install --ignore-workspace`.
+- Manage website deps with `--ignore-workspace` (e.g. `cd website && pnpm add --ignore-workspace <pkg>`). The repo root has a `pnpm-workspace.yaml`, so a plain `pnpm add` writes the dep to the root `pnpm-lock.yaml` instead of `website/pnpm-lock.yaml`, which breaks CI's `--frozen-lockfile` build.
+- The website uses relative imports (no `@/` alias); the `src/` Frontend rules above don't apply here.

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "7.2.0",
     "@astrojs/starlight": "0.40.0",
     "@tailwindcss/vite": "^4.1.17",
     "astro": "6.4.5",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: 7.2.0
+        version: 7.2.0
       '@astrojs/starlight':
         specifier: 0.40.0
         version: 0.40.0(astro@6.4.5(@types/node@24.13.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1))

--- a/website/src/components/landing/Header.astro
+++ b/website/src/components/landing/Header.astro
@@ -4,13 +4,16 @@ import GitHubLogo from "../../icons/github.astro"
 ---
 
 <header class="px-6 md:px-10 py-6 flex justify-between items-center">
-  <h1 aria-label="renCal">
-    <Logo class="h-[25px]" />
-    <span class="sr-only">renCal</span>
-  </h1>
+  <a href="/">
+    <h1 aria-label="renCal">
+      <Logo class="h-[25px]" />
+      <span class="sr-only">renCal</span>
+    </h1>
+  </a>
 
   <nav class="uppercase flex gap-7 text-foreground [&>a:hover]:underline">
     <a href="/docs/calendar-data">Docs</a>
+    <a href="/releases">Releases</a>
     <a href="https://github.com/t4t5/rencal" target="_blank" aria-label="GitHub repo">
       <GitHubLogo class="w-6" />
     </a>

--- a/website/src/components/landing/Header.astro
+++ b/website/src/components/landing/Header.astro
@@ -3,15 +3,17 @@ import Logo from "../../icons/rencal-logotype.astro"
 import GitHubLogo from "../../icons/github.astro"
 ---
 
-<header class="px-6 md:px-10 py-6 flex justify-between items-center">
+<header class="px-6 md:px-10 py-6 flex justify-between items-center gap-7">
   <a href="/">
-    <h1 aria-label="renCal">
+    <h1 aria-label="renCal" class="relative top-[-3px]">
       <Logo class="h-[25px]" />
       <span class="sr-only">renCal</span>
     </h1>
   </a>
 
-  <nav class="uppercase flex gap-7 text-foreground [&>a:hover]:underline">
+  <nav
+    class="text-sm gap-4 sm:text-base sm:gap-7 uppercase text-foreground [&>a:hover]:underline flex items-center"
+  >
     <a href="/docs/calendar-data">Docs</a>
     <a href="/releases">Releases</a>
     <a href="https://github.com/t4t5/rencal" target="_blank" aria-label="GitHub repo">

--- a/website/src/components/starlight/Header.astro
+++ b/website/src/components/starlight/Header.astro
@@ -29,14 +29,14 @@ const shouldRenderSearch =
       align-items: center;
       display: flex;
       gap: var(--sl-nav-gap);
-      padding: 4px 8px;
+      padding: 2px 8px;
       justify-content: space-between;
     }
 
     @media (min-width: 768px) {
       .header {
-        padding-left: 16px;
-        padding-right: 16px;
+        padding-left: 24px;
+        padding-right: 24px;
       }
     }
 
@@ -83,6 +83,8 @@ const shouldRenderSearch =
         --__toc-width: 0rem;
       }
       .header {
+        padding-left: 16px;
+        padding-right: 16px;
         --__sidebar-width: max(0rem, var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x));
         --__main-column-fr: calc(
           (

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,0 +1,36 @@
+---
+import Header from "../components/landing/Header.astro"
+import Footer from "../components/landing/Footer.astro"
+import { site } from "../site"
+
+interface Props {
+  title?: string
+  description?: string
+}
+
+const { title = site.title, description = site.description } = Astro.props
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:image" content={site.ogImage} />
+    <meta name="twitter:image" content={site.ogImage} />
+    <link rel="icon" type="image/svg+xml" href={site.favicon} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href={site.geistMonoStylesheet} rel="stylesheet" />
+    <script defer data-domain={site.analyticsDomain} src={site.analyticsScript}></script>
+  </head>
+  <body>
+    <Header />
+
+    <main class="flex flex-col gap-14">
+      <slot />
+      <Footer />
+    </main>
+  </body>
+</html>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,40 +1,15 @@
 ---
 import "../styles/index.css"
 
+import BaseLayout from "../layouts/BaseLayout.astro"
 import Hero from "../components/landing/Hero.astro"
-import Header from "../components/landing/Header.astro"
 import Features from "../components/landing/Features.astro"
 import OpenSource from "../components/landing/OpenSource.astro"
-import Footer from "../components/landing/Footer.astro"
-import { site } from "../site"
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>{site.title}</title>
-    <meta name="description" content={site.description} />
-    <meta property="og:image" content={site.ogImage} />
-    <meta name="twitter:image" content={site.ogImage} />
-    <link rel="icon" type="image/svg+xml" href={site.favicon} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href={site.geistMonoStylesheet}
-      rel="stylesheet"
-    />
-    <script defer data-domain={site.analyticsDomain} src={site.analyticsScript}></script>
-  </head>
-  <body>
-    <Header />
-
-    <main class="flex flex-col gap-14">
-      <Hero />
-      <Features />
-      <hr />
-      <OpenSource />
-      <Footer />
-    </main>
-  </body>
-</html>
+<BaseLayout>
+  <Hero />
+  <Features />
+  <hr />
+  <OpenSource />
+</BaseLayout>

--- a/website/src/pages/releases.astro
+++ b/website/src/pages/releases.astro
@@ -4,8 +4,7 @@ import "../styles/releases.css"
 
 import { createMarkdownProcessor } from "@astrojs/markdown-remark"
 
-import Header from "../components/landing/Header.astro"
-import Footer from "../components/landing/Footer.astro"
+import BaseLayout from "../layouts/BaseLayout.astro"
 import { site } from "../site"
 
 const REPO = "t4t5/rencal"
@@ -62,66 +61,45 @@ const entries = await Promise.all(
 )
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Releases · {site.title}</title>
-    <meta name="description" content={`Release notes for ${site.title}.`} />
-    <meta property="og:image" content={site.ogImage} />
-    <meta name="twitter:image" content={site.ogImage} />
-    <link rel="icon" type="image/svg+xml" href={site.favicon} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href={site.geistMonoStylesheet} rel="stylesheet" />
-    <script defer data-domain={site.analyticsDomain} src={site.analyticsScript}></script>
-  </head>
-  <body>
-    <Header />
+<BaseLayout title={`Releases · ${site.title}`} description={`Release notes for ${site.title}.`}>
+  <section class="mx-auto flex w-full max-w-3xl flex-col gap-12 px-6 md:px-10">
+    <h2 class="text-[30px] leading-tight uppercase md:text-[40px]">Releases</h2>
 
-    <main class="flex flex-col gap-14">
-      <section class="mx-auto flex w-full max-w-3xl flex-col gap-12 px-6 md:px-10">
-        <h2 class="text-[30px] leading-tight uppercase md:text-[40px]">Releases</h2>
+    {
+      entries.length === 0 ? (
+        <p>
+          Couldn't load releases right now. View them on{" "}
+          <a href={RELEASES_URL} class="text-primary hover:underline" target="_blank">
+            GitHub
+          </a>
+          .
+        </p>
+      ) : (
+        <div class="flex flex-col gap-16">
+          {entries.map((entry) => (
+            <>
+              <article class="flex flex-col gap-4">
+                <div class="flex flex-col gap-1">
+                  <h3 class="text-2xl">
+                    <a href={entry.url} class="hover:underline" target="_blank">
+                      {entry.title}
+                    </a>
+                    {entry.prerelease && (
+                      <span class="ml-3 border border-primary px-2 py-0.5 align-middle text-xs text-primary uppercase">
+                        Pre-release
+                      </span>
+                    )}
+                  </h3>
+                  {entry.date && <p class="text-sm text-muted opacity-70">{entry.date}</p>}
+                </div>
 
-        {
-          entries.length === 0 ? (
-            <p>
-              Couldn't load releases right now. View them on{" "}
-              <a href={RELEASES_URL} class="text-primary hover:underline" target="_blank">
-                GitHub
-              </a>
-              .
-            </p>
-          ) : (
-            <div class="flex flex-col gap-16">
-              {entries.map((entry) => (
-                <>
-                  <article class="flex flex-col gap-4">
-                    <div class="flex flex-col gap-1">
-                      <h3 class="text-2xl">
-                        <a href={entry.url} class="hover:underline" target="_blank">
-                          {entry.title}
-                        </a>
-                        {entry.prerelease && (
-                          <span class="ml-3 border border-primary px-2 py-0.5 align-middle text-xs text-primary uppercase">
-                            Pre-release
-                          </span>
-                        )}
-                      </h3>
-                      {entry.date && <p class="text-sm text-muted opacity-70">{entry.date}</p>}
-                    </div>
-
-                    <div class="release-body" set:html={entry.bodyHtml} />
-                  </article>
-                  <hr />
-                </>
-              ))}
-            </div>
-          )
-        }
-      </section>
-
-      <Footer />
-    </main>
-  </body>
-</html>
+                <div class="release-body" set:html={entry.bodyHtml} />
+              </article>
+              <hr />
+            </>
+          ))}
+        </div>
+      )
+    }
+  </section>
+</BaseLayout>

--- a/website/src/pages/releases.astro
+++ b/website/src/pages/releases.astro
@@ -62,9 +62,7 @@ const entries = await Promise.all(
 ---
 
 <BaseLayout title={`Releases · ${site.title}`} description={`Release notes for ${site.title}.`}>
-  <section class="mx-auto flex w-full max-w-3xl flex-col gap-12 px-6 md:px-10">
-    <h2 class="text-[30px] leading-tight uppercase md:text-[40px]">Releases</h2>
-
+  <section class="mx-auto flex w-full max-w-3xl flex-col px-6 md:px-10 pt-6">
     {
       entries.length === 0 ? (
         <p>
@@ -75,10 +73,10 @@ const entries = await Promise.all(
           .
         </p>
       ) : (
-        <div class="flex flex-col gap-16">
+        <div class="flex flex-col gap-8">
           {entries.map((entry) => (
             <>
-              <article class="flex flex-col gap-4">
+              <article class="flex flex-col gap-2">
                 <div class="flex flex-col gap-1">
                   <h3 class="text-2xl">
                     <a href={entry.url} class="hover:underline" target="_blank">

--- a/website/src/pages/releases.astro
+++ b/website/src/pages/releases.astro
@@ -1,0 +1,127 @@
+---
+import "../styles/index.css"
+import "../styles/releases.css"
+
+import { createMarkdownProcessor } from "@astrojs/markdown-remark"
+
+import Header from "../components/landing/Header.astro"
+import Footer from "../components/landing/Footer.astro"
+import { site } from "../site"
+
+const REPO = "t4t5/rencal"
+const RELEASES_URL = `https://github.com/${REPO}/releases`
+
+interface GitHubRelease {
+  name: string | null
+  tag_name: string
+  html_url: string
+  published_at: string | null
+  body: string | null
+  draft: boolean
+  prerelease: boolean
+}
+
+// Fetched at build time (Astro static output) — the result is baked into the
+// generated HTML, so visitors never hit the GitHub API.
+const headers: Record<string, string> = {
+  "User-Agent": "rencal-website",
+  Accept: "application/vnd.github+json",
+}
+if (process.env.GITHUB_TOKEN) {
+  headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+}
+
+let releases: GitHubRelease[] = []
+try {
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`, { headers })
+  if (!res.ok) {
+    throw new Error(`GitHub API responded ${res.status}`)
+  }
+  // API returns newest-first; drop drafts.
+  releases = ((await res.json()) as GitHubRelease[]).filter((release) => !release.draft)
+} catch (error) {
+  console.error("Failed to fetch releases from GitHub:", error)
+}
+
+const dateFormat = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+})
+
+const md = await createMarkdownProcessor()
+
+const entries = await Promise.all(
+  releases.map(async (release) => ({
+    title: release.name || release.tag_name,
+    url: release.html_url,
+    date: release.published_at ? dateFormat.format(new Date(release.published_at)) : null,
+    prerelease: release.prerelease,
+    bodyHtml: release.body ? (await md.render(release.body)).code : "",
+  })),
+)
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Releases · {site.title}</title>
+    <meta name="description" content={`Release notes for ${site.title}.`} />
+    <meta property="og:image" content={site.ogImage} />
+    <meta name="twitter:image" content={site.ogImage} />
+    <link rel="icon" type="image/svg+xml" href={site.favicon} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href={site.geistMonoStylesheet} rel="stylesheet" />
+    <script defer data-domain={site.analyticsDomain} src={site.analyticsScript}></script>
+  </head>
+  <body>
+    <Header />
+
+    <main class="flex flex-col gap-14">
+      <section class="mx-auto flex w-full max-w-3xl flex-col gap-12 px-6 md:px-10">
+        <h2 class="text-[30px] leading-tight uppercase md:text-[40px]">Releases</h2>
+
+        {
+          entries.length === 0 ? (
+            <p>
+              Couldn't load releases right now. View them on{" "}
+              <a href={RELEASES_URL} class="text-primary hover:underline" target="_blank">
+                GitHub
+              </a>
+              .
+            </p>
+          ) : (
+            <div class="flex flex-col gap-16">
+              {entries.map((entry) => (
+                <>
+                  <article class="flex flex-col gap-4">
+                    <div class="flex flex-col gap-1">
+                      <h3 class="text-2xl">
+                        <a href={entry.url} class="hover:underline" target="_blank">
+                          {entry.title}
+                        </a>
+                        {entry.prerelease && (
+                          <span class="ml-3 border border-primary px-2 py-0.5 align-middle text-xs text-primary uppercase">
+                            Pre-release
+                          </span>
+                        )}
+                      </h3>
+                      {entry.date && <p class="text-sm text-muted opacity-70">{entry.date}</p>}
+                    </div>
+
+                    <div class="release-body" set:html={entry.bodyHtml} />
+                  </article>
+                  <hr />
+                </>
+              ))}
+            </div>
+          )
+        }
+      </section>
+
+      <Footer />
+    </main>
+  </body>
+</html>

--- a/website/src/styles/docs.css
+++ b/website/src/styles/docs.css
@@ -16,7 +16,7 @@
   --sl-color-accent-low: rgba(245, 98, 19, 0.16);
   --sl-color-accent: #f56213;
   --sl-color-accent-high: inherit;
-  --sl-nav-height: 72px;
+  --sl-nav-height: 68px;
 
   /* Our headings are already uppercase, so we can make them smaller */
   --sl-text-h1: var(--sl-text-2xl);
@@ -121,7 +121,7 @@ site-search button[data-open-modal] {
 }
 
 starlight-menu-button button {
-  top: 16px;
+  top: 14px;
   width: 40px;
 }
 

--- a/website/src/styles/releases.css
+++ b/website/src/styles/releases.css
@@ -1,0 +1,79 @@
+/*
+ * Styles for GitHub-rendered release notes injected via `set:html`.
+ * These must be global (not Astro-scoped) to reach the injected markup.
+ */
+
+.release-body {
+  line-height: 1.6;
+}
+
+.release-body > * {
+  margin: 0;
+}
+
+.release-body > * + * {
+  margin-top: 0.85rem;
+}
+
+.release-body h1,
+.release-body h2,
+.release-body h3,
+.release-body h4 {
+  font-size: 1.125rem;
+  margin-top: 1.5rem;
+}
+
+.release-body ul,
+.release-body ol {
+  padding-left: 1.25rem;
+}
+
+.release-body ul {
+  list-style: disc;
+}
+
+.release-body ol {
+  list-style: decimal;
+}
+
+.release-body li {
+  margin-top: 0.35rem;
+}
+
+.release-body li::marker {
+  color: var(--muted);
+}
+
+.release-body a {
+  color: var(--primary);
+}
+
+.release-body a:hover {
+  text-decoration: underline;
+}
+
+.release-body code {
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 0.875em;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+}
+
+.release-body pre {
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+/* Shiki already styles code inside <pre>; reset the inline-code chrome there. */
+.release-body pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.release-body hr {
+  border: none;
+  border-top: 1px solid var(--separator);
+}


### PR DESCRIPTION
To make it easy for users to see what's changed.

Generates the data from GitHub Releases.

<img width="2814" height="1600" alt="image" src="https://github.com/user-attachments/assets/5d330a7c-f226-409c-930a-ae0f04e72d35" />
