### PR TITLE
Cleaner sync cloud status icon

### DIFF
--- a/src/components/toolbar/SyncStatus.tsx
+++ b/src/components/toolbar/SyncStatus.tsx
@@ -11,6 +11,7 @@ import { useSync } from "@/contexts/SyncContext"
 import { useIsOnline } from "@/hooks/useIsOnline"
 
 import { CloudIcon } from "@/icons/cloud"
+import { CloudCheckIcon } from "@/icons/cloud-check"
 import { CloudOffIcon } from "@/icons/cloud-off"
 import { CloudWarningIcon } from "@/icons/cloud-warning"
 import { SyncIcon as SyncingIcon } from "@/icons/sync"
@@ -28,16 +29,17 @@ export const SyncStatus = () => {
     0,
   )
 
-  let icon = (
-    <CloudIcon
-      className="size-5 text-muted-foreground pointer-events-none"
-      isLoading={isChecking}
-    />
-  )
+  let icon = <CloudCheckIcon className="size-5 text-muted-foreground pointer-events-none" />
 
   let tooltipContent: ReactNode = <>Up-to-date</>
 
   if (isChecking) {
+    icon = (
+      <CloudIcon
+        className="size-5 text-muted-foreground pointer-events-none"
+        isLoading={isChecking}
+      />
+    )
     tooltipContent = <>Checking for changes...</>
   }
 

--- a/src/components/toolbar/SyncStatus.tsx
+++ b/src/components/toolbar/SyncStatus.tsx
@@ -9,7 +9,6 @@ import { useSettings } from "@/contexts/SettingsContext"
 import { useSync } from "@/contexts/SyncContext"
 
 import { useIsOnline } from "@/hooks/useIsOnline"
-import { cn } from "@/lib/utils"
 
 import { CloudIcon } from "@/icons/cloud"
 import { CloudOffIcon } from "@/icons/cloud-off"
@@ -31,10 +30,8 @@ export const SyncStatus = () => {
 
   let icon = (
     <CloudIcon
-      className={cn(
-        "size-5 text-muted-foreground pointer-events-none",
-        isChecking && "animate-pulse",
-      )}
+      className="size-5 text-muted-foreground pointer-events-none"
+      isLoading={isChecking}
     />
   )
 

--- a/src/components/toolbar/SyncStatus.tsx
+++ b/src/components/toolbar/SyncStatus.tsx
@@ -44,6 +44,7 @@ export const SyncStatus = () => {
   }
 
   if (pendingCount) {
+    icon = <CloudIcon className="size-5 text-muted-foreground pointer-events-none" />
     tooltipContent = <ChangesPreview pendingPreviews={pendingPreviews} />
   }
 
@@ -77,7 +78,7 @@ export const SyncStatus = () => {
       size="icon"
       tabIndex={-1}
       className="relative focus-visible:ring-0"
-      onClick={pendingCount ? () => void handleSyncNow() : undefined}
+      onClick={() => void handleSyncNow()}
     >
       <div style={{ animation: "scale-in 0.15s ease-out" }}>{icon}</div>
 

--- a/src/icons/cloud-check.tsx
+++ b/src/icons/cloud-check.tsx
@@ -1,12 +1,18 @@
 export const CloudCheckIcon = ({ className }: { className?: string }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className={className}>
-    <g>
-      <path stroke="currentColor" d="m7.25 19 3.5 3.5 6 -7.5" strokeWidth={2} />
-      <path
-        stroke="currentColor"
-        d="M18.5 17.9753C21.0267 17.7245 23 15.5927 23 13c0 -2.7614 -2.2386 -5 -5 -5 0 -3.31371 -2.6863 -6 -6 -6 -2.6263 0 -4.8585 1.68739 -5.67159 4.03717C3.33081 6.37103 1 8.91332 1 12c0 2.6124 1.66962 4.8349 4 5.6586"
-        strokeWidth={2}
-      />
-    </g>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 13" className={className}>
+    <path
+      d="M3.25 11.08C1.74376 10.4677 0.681885 9.00158 0.681885 7.5C0.681885 5.39543 2.27107 3.66206 4.31489 3.43443C4.86927 1.83231 6.39123 0.681816 8.18188 0.681816C10.4412 0.681816 12.2728 2.51338 12.2728 4.77273C14.1556 4.77273 15.6819 6.29904 15.6819 8.18182C15.6819 9.40925 15.0279 10.4824 14.0496 11.0805"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.36364"
+    />
+    <path
+      d="m6.5 10.55 1.95 1.95 3.75 -4.7"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.36364"
+    />
   </svg>
 )

--- a/src/icons/cloud.tsx
+++ b/src/icons/cloud.tsx
@@ -1,9 +1,28 @@
-export const CloudIcon = ({ className }: { className?: string }) => (
+type CloudIconProps = {
+  className?: string
+  isLoading?: boolean
+}
+
+export const CloudIcon = ({ className, isLoading = false }: CloudIconProps) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 13" className={className}>
     <path
       d="M0.681885 7.5C0.681885 9.75934 2.51345 11.5909 4.77279 11.5909H12.2728C14.1556 11.5909 15.6819 10.0646 15.6819 8.18182C15.6819 6.29904 14.1556 4.77273 12.2728 4.77273C12.2728 2.51338 10.4412 0.681816 8.18188 0.681816C6.39123 0.681816 4.86927 1.83231 4.31489 3.43443C2.27107 3.66206 0.681885 5.39543 0.681885 7.5Z"
+      pathLength={100}
       stroke="currentColor"
+      strokeDasharray={isLoading ? "82 14" : undefined}
+      strokeLinecap="round"
+      strokeLinejoin="round"
       strokeWidth="1.36364"
-    />
+    >
+      {isLoading && (
+        <animate
+          attributeName="stroke-dashoffset"
+          dur="1s"
+          from="0"
+          repeatCount="indefinite"
+          to="100"
+        />
+      )}
+    </path>
   </svg>
 )


### PR DESCRIPTION
We want a clearer distinction between when caldir is checking for diffs against our remote and when it's all done and up-to-date.

<img width="392" height="126" alt="image" src="https://github.com/user-attachments/assets/aa52b586-323b-4380-a01b-4dffd13cef68" />

<img width="360" height="126" alt="image" src="https://github.com/user-attachments/assets/09c6aaa0-8d59-4a92-afe0-29dbe96fb08e" />
