### PR TITLE
Add items to native macOS menu

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -552,6 +552,8 @@ dependencies = [
 [[package]]
 name = "caldir-core"
 version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7085384510ed75c303119e600d4bda6045c139409ac8cb2a5c11407bf8995983"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ mod event_cache;
 mod external_themes;
 #[cfg(target_os = "linux")]
 mod linux_reminders;
+#[cfg(target_os = "macos")]
+mod menu;
 mod notifications;
 mod oauth;
 mod omarchy;
@@ -129,6 +131,12 @@ pub async fn run() {
             let _ = window.set_focus();
         }
     }));
+
+    // Native macOS menu bar (other platforms use custom titlebars, no global menu).
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .menu(menu::build_menu)
+        .on_menu_event(menu::handle_menu_event);
 
     builder
         .plugin(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,7 +132,7 @@ pub async fn run() {
         }
     }));
 
-    // Native macOS menu bar (other platforms use custom titlebars, no global menu).
+    // Native macOS menu bar
     #[cfg(target_os = "macos")]
     let builder = builder
         .menu(menu::build_menu)

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,13 +1,4 @@
 //! Native macOS application menu.
-//!
-//! Surfaces renCal's key actions in the macOS menu bar. Custom items emit a
-//! `menu-action` event carrying a frontend `ShortcutId`; the React side
-//! dispatches it through the same handler table the keyboard shortcuts use
-//! (see `src/components/shortcuts/GlobalShortcuts.tsx`). Help links are opened
-//! directly here via the opener plugin.
-//!
-//! This module is compiled on macOS only — other platforms use custom
-//! titlebars without a global menu bar.
 
 use tauri::{
     AppHandle, Emitter, Runtime,
@@ -18,14 +9,11 @@ use tauri_plugin_opener::OpenerExt;
 const WEBSITE_URL: &str = "https://rencal.org";
 const ISSUES_URL: &str = "https://github.com/t4t5/rencal/issues/new";
 
-/// Builds the full application menu. Item ids match frontend `ShortcutId`s so
-/// the frontend can dispatch them directly.
 pub fn build_menu<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     let settings = MenuItemBuilder::with_id("settings", "Settings…")
         .accelerator("CmdOrCtrl+,")
         .build(handle)?;
 
-    // First submenu becomes the application menu on macOS (titled with the app name).
     let app_menu = SubmenuBuilder::new(handle, "renCal")
         .about(None)
         .separator()
@@ -49,8 +37,6 @@ pub fn build_menu<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         .close_window()
         .build()?;
 
-    // Standard editing items — kept so copy/paste/undo work in text inputs
-    // once we replace Tauri's default menu.
     let edit_menu = SubmenuBuilder::new(handle, "Edit")
         .undo()
         .redo()
@@ -116,9 +102,6 @@ pub fn build_menu<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
     )
 }
 
-/// Routes menu clicks. Help links open in the browser; every other custom item
-/// is forwarded to the frontend as a `menu-action` event (only the calendar
-/// window listens). Predefined items handle themselves and don't reach here.
 pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: MenuEvent) {
     match event.id().as_ref() {
         "help-website" => {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,0 +1,134 @@
+//! Native macOS application menu.
+//!
+//! Surfaces renCal's key actions in the macOS menu bar. Custom items emit a
+//! `menu-action` event carrying a frontend `ShortcutId`; the React side
+//! dispatches it through the same handler table the keyboard shortcuts use
+//! (see `src/components/shortcuts/GlobalShortcuts.tsx`). Help links are opened
+//! directly here via the opener plugin.
+//!
+//! This module is compiled on macOS only — other platforms use custom
+//! titlebars without a global menu bar.
+
+use tauri::{
+    AppHandle, Emitter, Runtime,
+    menu::{Menu, MenuEvent, MenuItemBuilder, SubmenuBuilder},
+};
+use tauri_plugin_opener::OpenerExt;
+
+const WEBSITE_URL: &str = "https://rencal.org";
+const ISSUES_URL: &str = "https://github.com/t4t5/rencal/issues/new";
+
+/// Builds the full application menu. Item ids match frontend `ShortcutId`s so
+/// the frontend can dispatch them directly.
+pub fn build_menu<R: Runtime>(handle: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let settings = MenuItemBuilder::with_id("settings", "Settings…")
+        .accelerator("CmdOrCtrl+,")
+        .build(handle)?;
+
+    // First submenu becomes the application menu on macOS (titled with the app name).
+    let app_menu = SubmenuBuilder::new(handle, "renCal")
+        .about(None)
+        .separator()
+        .item(&settings)
+        .separator()
+        .services()
+        .separator()
+        .hide()
+        .hide_others()
+        .show_all()
+        .separator()
+        .quit()
+        .build()?;
+
+    let new_event = MenuItemBuilder::with_id("compose-event", "New Event")
+        .accelerator("CmdOrCtrl+N")
+        .build(handle)?;
+    let file_menu = SubmenuBuilder::new(handle, "File")
+        .item(&new_event)
+        .separator()
+        .close_window()
+        .build()?;
+
+    // Standard editing items — kept so copy/paste/undo work in text inputs
+    // once we replace Tauri's default menu.
+    let edit_menu = SubmenuBuilder::new(handle, "Edit")
+        .undo()
+        .redo()
+        .separator()
+        .cut()
+        .copy()
+        .paste()
+        .select_all()
+        .build()?;
+
+    // Views use Cmd+1/2/3 to avoid clobbering system Cmd+W (close) / Cmd+M (minimize).
+    let week = MenuItemBuilder::with_id("week", "Week")
+        .accelerator("CmdOrCtrl+1")
+        .build(handle)?;
+    let month = MenuItemBuilder::with_id("month", "Month")
+        .accelerator("CmdOrCtrl+2")
+        .build(handle)?;
+    let board = MenuItemBuilder::with_id("board", "Board")
+        .accelerator("CmdOrCtrl+3")
+        .build(handle)?;
+    let today = MenuItemBuilder::with_id("today", "Go to Today")
+        .accelerator("CmdOrCtrl+T")
+        .build(handle)?;
+    let go_to_date = MenuItemBuilder::with_id("go-to-date", "Go to Date…")
+        .accelerator("CmdOrCtrl+G")
+        .build(handle)?;
+    let view_menu = SubmenuBuilder::new(handle, "View")
+        .item(&week)
+        .item(&month)
+        .item(&board)
+        .separator()
+        .item(&today)
+        .item(&go_to_date)
+        .build()?;
+
+    let window_menu = SubmenuBuilder::new(handle, "Window")
+        .minimize()
+        .maximize()
+        .build()?;
+
+    let shortcuts = MenuItemBuilder::with_id("shortcuts", "Keyboard Shortcuts")
+        .accelerator("CmdOrCtrl+/")
+        .build(handle)?;
+    let website = MenuItemBuilder::with_id("help-website", "renCal Website").build(handle)?;
+    let issues = MenuItemBuilder::with_id("help-issues", "Report an Issue").build(handle)?;
+    let help_menu = SubmenuBuilder::new(handle, "Help")
+        .item(&shortcuts)
+        .separator()
+        .item(&website)
+        .item(&issues)
+        .build()?;
+
+    Menu::with_items(
+        handle,
+        &[
+            &app_menu,
+            &file_menu,
+            &edit_menu,
+            &view_menu,
+            &window_menu,
+            &help_menu,
+        ],
+    )
+}
+
+/// Routes menu clicks. Help links open in the browser; every other custom item
+/// is forwarded to the frontend as a `menu-action` event (only the calendar
+/// window listens). Predefined items handle themselves and don't reach here.
+pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: MenuEvent) {
+    match event.id().as_ref() {
+        "help-website" => {
+            let _ = app.opener().open_url(WEBSITE_URL, None::<&str>);
+        }
+        "help-issues" => {
+            let _ = app.opener().open_url(ISSUES_URL, None::<&str>);
+        }
+        id => {
+            let _ = app.emit("menu-action", id);
+        }
+    }
+}

--- a/src/components/shortcuts/GlobalShortcuts.tsx
+++ b/src/components/shortcuts/GlobalShortcuts.tsx
@@ -1,5 +1,6 @@
+import { listen } from "@tauri-apps/api/event"
 import { addDays, addMonths, isSameDay, startOfMonth, subDays, subMonths } from "date-fns"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 
 import { CommandPalette } from "@/components/shortcuts/CommandPalette"
@@ -67,6 +68,13 @@ export function GlobalShortcuts({
     activeGroup,
     setActiveGroup,
   })
+
+  // Native macOS menu items emit `menu-action` with a ShortcutId; dispatch it
+  // through the same handler table the keyboard shortcuts use.
+  useEffect(() => {
+    const unlisten = listen<ShortcutId>("menu-action", (e) => handlers[e.payload]?.())
+    return () => void unlisten.then((off) => off())
+  }, [handlers])
 
   const groupOptions = getGroupOptions(groups)
 

--- a/src/components/shortcuts/GlobalShortcuts.tsx
+++ b/src/components/shortcuts/GlobalShortcuts.tsx
@@ -69,8 +69,7 @@ export function GlobalShortcuts({
     setActiveGroup,
   })
 
-  // Native macOS menu items emit `menu-action` with a ShortcutId; dispatch it
-  // through the same handler table the keyboard shortcuts use.
+  // Native macOS menu items (emit `menu-action` with a ShortcutId)
   useEffect(() => {
     const unlisten = listen<ShortcutId>("menu-action", (e) => handlers[e.payload]?.())
     return () => void unlisten.then((off) => off())


### PR DESCRIPTION
Makes the app feel more native on macOS.

<img width="772" height="402" alt="CleanShot 2026-06-30 at 07 47 03@2x" src="https://github.com/user-attachments/assets/dd30a56b-34e9-474c-8706-5d23f80b74f8" />
