### PR TITLE
Use rounded notification icon

### DIFF
--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -49,7 +49,7 @@ export function InvitesBadge() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button className="flex size-7 items-center justify-center rounded-circle bg-red-500 text-xs font-medium text-white cursor-pointer hover:bg-red-600 transition-colors">
+        <button className="flex size-6 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white cursor-pointer hover:bg-red-600 transition-colors outline-none">
           {invites.length}
         </button>
       </PopoverTrigger>
@@ -95,7 +95,7 @@ function InviteCard({
       <div className="flex gap-3 p-3">
         <span
           className={cn(
-            "flex size-8 shrink-0 items-center justify-center rounded-circle text-xs font-medium text-white bg-muted-foreground",
+            "flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white bg-muted-foreground",
           )}
         >
           {initial}


### PR DESCRIPTION
I wanted to avoid rounded corners as much as possible, but in this case, it just looks way better.

**Before:**

<img width="944" height="508" alt="screenshot-2026-07-02_08-10-13" src="https://github.com/user-attachments/assets/8d720ee0-b7f8-4c98-9ad6-78b0be27d312" />

**After:**

<img width="922" height="500" alt="screenshot-2026-07-02_08-13-24" src="https://github.com/user-attachments/assets/e583f55f-1f1f-4e30-96ff-7463e319b19e" />
