### PR TITLE
Auto-suggest contacts when adding invitees

### DIFF
--- a/src-tauri/src/routes/caldir/list_contacts.rs
+++ b/src-tauri/src/routes/caldir/list_contacts.rs
@@ -1,0 +1,146 @@
+use super::helpers::load_caldir;
+use super::types::Contact;
+use crate::event_cache::EVENT_CACHE;
+use crate::routes::TauResult;
+use caldir_core::{Attendee, Event};
+use chrono::{DateTime, Utc};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone)]
+struct ContactAgg {
+    email: String,
+    name: Option<String>,
+    count: u32,
+    last_seen: DateTime<Utc>,
+}
+
+pub(super) async fn handler() -> TauResult<Vec<Contact>> {
+    let caldir = load_caldir()?;
+    let calendars: Vec<_> = caldir.calendars().into_iter().filter_map(Result::ok).collect();
+
+    let own_addresses: HashSet<String> = calendars
+        .iter()
+        .filter_map(|calendar| calendar.remote_email())
+        .map(normalize_email)
+        .filter(|email| !email.is_empty())
+        .collect();
+
+    let mut contacts: HashMap<String, ContactAgg> = HashMap::new();
+    let mut counted_events: HashSet<(String, String)> = HashSet::new();
+
+    for calendar in calendars {
+        let Some(slug) = calendar.slug() else {
+            continue;
+        };
+
+        let events = EVENT_CACHE.events(&caldir, slug)?;
+        for event in events.iter() {
+            fold_event_contacts(event, &own_addresses, &mut contacts, &mut counted_events);
+        }
+    }
+
+    let mut contacts: Vec<Contact> = contacts
+        .into_values()
+        .map(|contact| Contact {
+            email: contact.email,
+            name: contact.name,
+            count: contact.count,
+            last_seen: contact.last_seen.date_naive().format("%F").to_string(),
+        })
+        .collect();
+
+    contacts.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| b.last_seen.cmp(&a.last_seen))
+            .then_with(|| a.email.cmp(&b.email))
+    });
+
+    Ok(contacts)
+}
+
+fn fold_event_contacts(
+    event: &Event,
+    own_addresses: &HashSet<String>,
+    contacts: &mut HashMap<String, ContactAgg>,
+    counted_events: &mut HashSet<(String, String)>,
+) {
+    if let Some(organizer) = &event.organizer {
+        fold_contact(
+            &organizer.email,
+            organizer.name.as_deref(),
+            event,
+            own_addresses,
+            contacts,
+            counted_events,
+        );
+    }
+
+    for attendee in &event.attendees {
+        fold_attendee(attendee, event, own_addresses, contacts, counted_events);
+    }
+}
+
+fn fold_attendee(
+    attendee: &Attendee,
+    event: &Event,
+    own_addresses: &HashSet<String>,
+    contacts: &mut HashMap<String, ContactAgg>,
+    counted_events: &mut HashSet<(String, String)>,
+) {
+    fold_contact(
+        &attendee.email,
+        attendee.name.as_deref(),
+        event,
+        own_addresses,
+        contacts,
+        counted_events,
+    );
+}
+
+fn fold_contact(
+    raw_email: &str,
+    raw_name: Option<&str>,
+    event: &Event,
+    own_addresses: &HashSet<String>,
+    contacts: &mut HashMap<String, ContactAgg>,
+    counted_events: &mut HashSet<(String, String)>,
+) {
+    let email = normalize_email(raw_email);
+    if email.is_empty() || own_addresses.contains(&email) {
+        return;
+    }
+
+    let event_start = event.start.to_utc();
+    let event_uid = event.uid.as_str().to_string();
+    let count_key = (email.clone(), event_uid);
+    let count_increment = counted_events.insert(count_key);
+    let name = raw_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned);
+
+    contacts
+        .entry(email.clone())
+        .and_modify(|contact| {
+            if count_increment {
+                contact.count += 1;
+            }
+            if event_start >= contact.last_seen {
+                contact.last_seen = event_start;
+                if let Some(name) = &name {
+                    contact.name = Some(name.clone());
+                }
+            }
+        })
+        .or_insert_with(|| ContactAgg {
+            email,
+            name,
+            count: u32::from(count_increment),
+            last_seen: event_start,
+        });
+}
+
+fn normalize_email(email: &str) -> String {
+    email.trim().to_lowercase()
+}

--- a/src-tauri/src/routes/caldir/mod.rs
+++ b/src-tauri/src/routes/caldir/mod.rs
@@ -13,6 +13,7 @@ mod get_config;
 mod get_event;
 mod get_provider_connect_info;
 mod list_calendars;
+mod list_contacts;
 mod list_events;
 mod list_invites;
 mod list_providers;
@@ -25,7 +26,7 @@ mod sync_preview;
 mod update_event;
 
 pub use types::{
-    Calendar, CalendarEvent, CreateEventInput, CredentialFieldInput, ProviderConnectInfo,
+    Calendar, CalendarEvent, Contact, CreateEventInput, CredentialFieldInput, ProviderConnectInfo,
     SplitRecurringSeriesInput, SyncPreview, TimeFormat, UpdateEventInput,
 };
 
@@ -35,6 +36,7 @@ use tauri::{AppHandle, Runtime};
 #[taurpc::procedures(path = "caldir", export_to = "../src/rpc/bindings.ts")]
 pub trait CaldirApi {
     async fn list_calendars() -> TauResult<Vec<Calendar>>;
+    async fn list_contacts() -> TauResult<Vec<Contact>>;
     async fn list_events(
         calendar_slugs: Vec<String>,
         start: String,
@@ -103,6 +105,10 @@ pub struct CaldirApiImpl;
 impl CaldirApi for CaldirApiImpl {
     async fn list_calendars(self) -> TauResult<Vec<Calendar>> {
         list_calendars::handler().await
+    }
+
+    async fn list_contacts(self) -> TauResult<Vec<Contact>> {
+        list_contacts::handler().await
     }
 
     async fn list_events(

--- a/src-tauri/src/routes/caldir/types.rs
+++ b/src-tauri/src/routes/caldir/types.rs
@@ -36,6 +36,14 @@ pub struct RpcRecurrence {
 }
 
 #[derive(Clone, Serialize, Deserialize, Type)]
+pub struct Contact {
+    pub email: String,
+    pub name: Option<String>,
+    pub count: u32,
+    pub last_seen: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, Type)]
 pub enum TimeFormat {
     #[serde(rename = "24h")]
     H24,

--- a/src/components/event-parts/inputs/AttendeesDisplay.tsx
+++ b/src/components/event-parts/inputs/AttendeesDisplay.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import type { KeyboardEvent } from "react"
 
 import { Command, CommandItem, CommandList } from "@/components/ui/command"
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group"
@@ -36,9 +37,11 @@ export function AttendeesDisplay({
   const canEdit = !readOnly && !!onAttendeesChange
   const contacts = useContacts(canEdit)
   const attendeeList = attendees ?? []
+
   const organizerAttendee = organizer
     ? attendeeList.find((a) => attendeeKey(a.email) === attendeeKey(organizer.email))
     : null
+
   const hasAttendees = attendeeList.length > 0
   const excludeEmails = useMemo(
     () => [
@@ -47,10 +50,12 @@ export function AttendeesDisplay({
     ],
     [attendeeList, organizer?.email],
   )
+
   const suggestions = useMemo(
     () => suggestContacts(contacts, inputValue, excludeEmails),
     [contacts, excludeEmails, inputValue],
   )
+
   const showSuggestions =
     canEdit && !suggestionsDismissed && inputValue.trim().length > 0 && suggestions.length > 0
 
@@ -84,12 +89,14 @@ export function AttendeesDisplay({
 
   const addSuggestedAttendee = (index: number) => {
     const contact = suggestions[index]
+
     if (!contact) return
 
     onAttendeesChange?.([
       ...attendeeList,
       { name: contact.name, email: contact.email, response_status: "needs-action" },
     ])
+
     setInputValue("")
     setHasInvalidEmail(false)
     setHighlightedIndex(0)
@@ -98,6 +105,40 @@ export function AttendeesDisplay({
 
   const removeAttendee = (email: string) => {
     onAttendeesChange?.(attendeeList.filter((attendee) => attendeeKey(attendee.email) !== email))
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" && suggestions.length > 0) {
+      e.preventDefault()
+      setHighlightedIndex((index) => (index + 1) % suggestions.length)
+      return
+    }
+
+    if (e.key === "ArrowUp" && suggestions.length > 0) {
+      e.preventDefault()
+      setHighlightedIndex((index) => (index === 0 ? suggestions.length - 1 : index - 1))
+      return
+    }
+
+    if (e.key === "Escape" && showSuggestions) {
+      e.preventDefault()
+      setSuggestionsDismissed(true)
+      setHighlightedIndex(0)
+      return
+    }
+
+    if (e.key === "Enter" && showSuggestions) {
+      e.preventDefault()
+      addSuggestedAttendee(highlightedIndex)
+      return
+    }
+
+    if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+      if (inputValue.trim()) {
+        e.preventDefault()
+        addAttendee()
+      }
+    }
   }
 
   return (
@@ -119,7 +160,7 @@ export function AttendeesDisplay({
           <PopoverAnchor asChild>
             <InputGroup
               className={cn("w-auto", {
-                "ml-7": !!attendees?.length,
+                "mt-1": !!attendees?.length,
               })}
             >
               {!attendees?.length && (
@@ -142,41 +183,7 @@ export function AttendeesDisplay({
                 onBlur={() => {
                   if (inputValue.trim()) addAttendee()
                 }}
-                onKeyDown={(e) => {
-                  if (e.key === "ArrowDown" && suggestions.length > 0) {
-                    e.preventDefault()
-                    setHighlightedIndex((index) => (index + 1) % suggestions.length)
-                    return
-                  }
-
-                  if (e.key === "ArrowUp" && suggestions.length > 0) {
-                    e.preventDefault()
-                    setHighlightedIndex((index) =>
-                      index === 0 ? suggestions.length - 1 : index - 1,
-                    )
-                    return
-                  }
-
-                  if (e.key === "Escape" && showSuggestions) {
-                    e.preventDefault()
-                    setSuggestionsDismissed(true)
-                    setHighlightedIndex(0)
-                    return
-                  }
-
-                  if (e.key === "Enter" && showSuggestions) {
-                    e.preventDefault()
-                    addSuggestedAttendee(highlightedIndex)
-                    return
-                  }
-
-                  if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
-                    if (inputValue.trim()) {
-                      e.preventDefault()
-                      addAttendee()
-                    }
-                  }
-                }}
+                onKeyDown={onKeyDown}
               />
             </InputGroup>
           </PopoverAnchor>

--- a/src/components/event-parts/inputs/AttendeesDisplay.tsx
+++ b/src/components/event-parts/inputs/AttendeesDisplay.tsx
@@ -5,6 +5,7 @@ import { Command, CommandItem, CommandList } from "@/components/ui/command"
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group"
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { StatusDot } from "@/components/ui/status-dot"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 import { EventAttendee } from "@/rpc/bindings"
 
@@ -242,8 +243,9 @@ function AttendeeRow({
   onRemove?: () => void
 }) {
   const displayName = attendee.name ?? attendee.email
+  const showEmailTooltip = !!attendee.name && attendee.name !== attendee.email
 
-  return (
+  const row = (
     <div className="group flex items-center gap-2 py-1 px-3 text-sm">
       <StatusDot status={attendee.response_status} />
 
@@ -254,5 +256,14 @@ function AttendeeRow({
 
       {onRemove && <RemoveItemButton onClick={onRemove} />}
     </div>
+  )
+
+  if (!showEmailTooltip) return row
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      <TooltipContent>{attendee.email}</TooltipContent>
+    </Tooltip>
   )
 }

--- a/src/components/event-parts/inputs/AttendeesDisplay.tsx
+++ b/src/components/event-parts/inputs/AttendeesDisplay.tsx
@@ -10,14 +10,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { EventAttendee } from "@/rpc/bindings"
 
 import { useContacts } from "@/hooks/useContacts"
-import { suggestContacts } from "@/lib/contact-suggestions"
+import { isValidContactEmail, suggestContacts } from "@/lib/contact-suggestions"
 import { cn } from "@/lib/utils"
 
 import { UserIcon } from "@/icons/user"
 
 import { RemoveItemButton } from "./RemoveItemButton"
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 export function AttendeesDisplay({
   organizer,
@@ -70,7 +68,7 @@ export function AttendeesDisplay({
       return
     }
 
-    if (!EMAIL_RE.test(email)) {
+    if (!isValidContactEmail(email)) {
       setHasInvalidEmail(true)
       return
     }
@@ -91,7 +89,7 @@ export function AttendeesDisplay({
   const addSuggestedAttendee = (index: number) => {
     const contact = suggestions[index]
 
-    if (!contact) return
+    if (!contact || !isValidContactEmail(contact.email)) return
 
     onAttendeesChange?.([
       ...attendeeList,

--- a/src/components/event-parts/inputs/AttendeesDisplay.tsx
+++ b/src/components/event-parts/inputs/AttendeesDisplay.tsx
@@ -1,10 +1,14 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
+import { Command, CommandItem, CommandList } from "@/components/ui/command"
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group"
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
 import { StatusDot } from "@/components/ui/status-dot"
 
 import { EventAttendee } from "@/rpc/bindings"
 
+import { useContacts } from "@/hooks/useContacts"
+import { suggestContacts } from "@/lib/contact-suggestions"
 import { cn } from "@/lib/utils"
 
 import { UserIcon } from "@/icons/user"
@@ -26,13 +30,29 @@ export function AttendeesDisplay({
 }) {
   const [inputValue, setInputValue] = useState("")
   const [hasInvalidEmail, setHasInvalidEmail] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const [suggestionsDismissed, setSuggestionsDismissed] = useState(false)
 
   const canEdit = !readOnly && !!onAttendeesChange
+  const contacts = useContacts(canEdit)
   const attendeeList = attendees ?? []
   const organizerAttendee = organizer
     ? attendeeList.find((a) => attendeeKey(a.email) === attendeeKey(organizer.email))
     : null
   const hasAttendees = attendeeList.length > 0
+  const excludeEmails = useMemo(
+    () => [
+      ...attendeeList.map((attendee) => attendee.email),
+      ...(organizer?.email ? [organizer.email] : []),
+    ],
+    [attendeeList, organizer?.email],
+  )
+  const suggestions = useMemo(
+    () => suggestContacts(contacts, inputValue, excludeEmails),
+    [contacts, excludeEmails, inputValue],
+  )
+  const showSuggestions =
+    canEdit && !suggestionsDismissed && inputValue.trim().length > 0 && suggestions.length > 0
 
   if (!hasAttendees && !canEdit) return null
 
@@ -58,6 +78,22 @@ export function AttendeesDisplay({
 
     setInputValue("")
     setHasInvalidEmail(false)
+    setHighlightedIndex(0)
+    setSuggestionsDismissed(false)
+  }
+
+  const addSuggestedAttendee = (index: number) => {
+    const contact = suggestions[index]
+    if (!contact) return
+
+    onAttendeesChange?.([
+      ...attendeeList,
+      { name: contact.name, email: contact.email, response_status: "needs-action" },
+    ])
+    setInputValue("")
+    setHasInvalidEmail(false)
+    setHighlightedIndex(0)
+    setSuggestionsDismissed(false)
   }
 
   const removeAttendee = (email: string) => {
@@ -79,39 +115,107 @@ export function AttendeesDisplay({
         ))}
 
       {canEdit && (
-        <InputGroup
-          className={cn("w-auto", {
-            "ml-7": !!attendees?.length,
-          })}
-        >
-          {!attendees?.length && (
-            <InputGroupAddon>
-              <UserIcon />
-            </InputGroupAddon>
-          )}
+        <Popover open={showSuggestions}>
+          <PopoverAnchor asChild>
+            <InputGroup
+              className={cn("w-auto", {
+                "ml-7": !!attendees?.length,
+              })}
+            >
+              {!attendees?.length && (
+                <InputGroupAddon>
+                  <UserIcon />
+                </InputGroupAddon>
+              )}
 
-          <InputGroupInput
-            value={inputValue}
-            placeholder={"Add participant"}
-            className="min-w-0 px-2 text-sm"
-            aria-invalid={hasInvalidEmail}
-            onChange={(e) => {
-              setInputValue(e.target.value)
-              setHasInvalidEmail(false)
-            }}
-            onBlur={() => {
-              if (inputValue.trim()) addAttendee()
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
-                if (inputValue.trim()) {
-                  e.preventDefault()
-                  addAttendee()
-                }
-              }
-            }}
-          />
-        </InputGroup>
+              <InputGroupInput
+                value={inputValue}
+                placeholder={"Add participant"}
+                className="min-w-0 px-2 text-sm"
+                aria-invalid={hasInvalidEmail}
+                onChange={(e) => {
+                  setInputValue(e.target.value)
+                  setHasInvalidEmail(false)
+                  setHighlightedIndex(0)
+                  setSuggestionsDismissed(false)
+                }}
+                onBlur={() => {
+                  if (inputValue.trim()) addAttendee()
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowDown" && suggestions.length > 0) {
+                    e.preventDefault()
+                    setHighlightedIndex((index) => (index + 1) % suggestions.length)
+                    return
+                  }
+
+                  if (e.key === "ArrowUp" && suggestions.length > 0) {
+                    e.preventDefault()
+                    setHighlightedIndex((index) =>
+                      index === 0 ? suggestions.length - 1 : index - 1,
+                    )
+                    return
+                  }
+
+                  if (e.key === "Escape" && showSuggestions) {
+                    e.preventDefault()
+                    setSuggestionsDismissed(true)
+                    setHighlightedIndex(0)
+                    return
+                  }
+
+                  if (e.key === "Enter" && showSuggestions) {
+                    e.preventDefault()
+                    addSuggestedAttendee(highlightedIndex)
+                    return
+                  }
+
+                  if (e.key === "Enter" || e.key === "," || e.key === "Tab") {
+                    if (inputValue.trim()) {
+                      e.preventDefault()
+                      addAttendee()
+                    }
+                  }
+                }}
+              />
+            </InputGroup>
+          </PopoverAnchor>
+
+          <PopoverContent
+            className="w-(--radix-popover-trigger-width) p-0"
+            align="start"
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            <Command
+              value={suggestions[highlightedIndex]?.email}
+              onValueChange={(value) => {
+                const index = suggestions.findIndex((contact) => contact.email === value)
+                if (index >= 0) setHighlightedIndex(index)
+              }}
+            >
+              <CommandList>
+                {suggestions.map((contact, index) => (
+                  <CommandItem
+                    key={contact.email}
+                    value={contact.email}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onSelect={() => addSuggestedAttendee(index)}
+                    className="items-start"
+                  >
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate">{contact.name ?? contact.email}</span>
+                      {contact.name && (
+                        <span className="truncate text-xs text-muted-foreground">
+                          {contact.email}
+                        </span>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       )}
     </div>
   )

--- a/src/global.css
+++ b/src/global.css
@@ -59,6 +59,8 @@
 
   --hover-tint: white;
   --hover-mix: 5%;
+  --popover-tint: black;
+  --popover-mix: 4%;
 
   --tab-gap: 0;
   --tab-list-shadow: none;
@@ -84,7 +86,7 @@ body {
   --primary-hover: color-mix(in srgb, white var(--hover-mix), var(--primary));
   --primary-foreground: var(--background);
 
-  --popover: var(--card);
+  --popover: color-mix(in srgb, var(--popover-tint) var(--popover-mix), var(--background));
   --popover-foreground: var(--foreground);
 
   --destructive: var(--error);

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -1,0 +1,58 @@
+import { listen } from "@tauri-apps/api/event"
+import { useEffect, useState } from "react"
+
+import { rpc } from "@/rpc"
+import type { Contact } from "@/rpc/bindings"
+import { CALDIR_CHANGED } from "@/rpc/events"
+
+let cachedContacts: Contact[] | null = null
+let contactsPromise: Promise<Contact[]> | null = null
+
+export function useContacts(enabled: boolean) {
+  const [contacts, setContacts] = useState<Contact[]>(cachedContacts ?? [])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    const load = () => {
+      void loadContacts().then((loaded) => {
+        if (!cancelled) {
+          setContacts(loaded)
+        }
+      })
+    }
+
+    load()
+
+    const unlisten = listen(CALDIR_CHANGED, () => {
+      invalidateContacts()
+      load()
+    })
+
+    return () => {
+      cancelled = true
+      unlisten.then((fn) => fn())
+    }
+  }, [enabled])
+
+  return contacts
+}
+
+function loadContacts(): Promise<Contact[]> {
+  if (cachedContacts) return Promise.resolve(cachedContacts)
+
+  contactsPromise ??= rpc.caldir.list_contacts().then((contacts) => {
+    cachedContacts = contacts
+    contactsPromise = null
+    return contacts
+  })
+
+  return contactsPromise
+}
+
+function invalidateContacts() {
+  cachedContacts = null
+  contactsPromise = null
+}

--- a/src/hooks/useOmarchyTheme.ts
+++ b/src/hooks/useOmarchyTheme.ts
@@ -19,6 +19,7 @@ const CSS_VARS = [
   "--highlight",
   "--hover-tint",
   "--muted",
+  "--popover-tint",
   "--success",
   "--warning",
   "--error",
@@ -46,6 +47,7 @@ function pickForeground(c: OmarchyColors): string {
 
 function varsFromColors(c: OmarchyColors): Record<(typeof CSS_VARS)[number], string> {
   const fg = pickForeground(c)
+  const popoverTint = appearanceFromHex(c.background) === "light" ? "white" : "black"
   return {
     "--background": c.background,
     "--foreground": fg,
@@ -54,6 +56,7 @@ function varsFromColors(c: OmarchyColors): Record<(typeof CSS_VARS)[number], str
     "--highlight": c.color1,
     "--hover-tint": fg,
     "--muted": `color-mix(in srgb, ${fg} 55%, transparent)`,
+    "--popover-tint": popoverTint,
     "--success": c.color2,
     "--warning": c.color3,
     "--error": c.color1,

--- a/src/lib/contact-suggestions.test.ts
+++ b/src/lib/contact-suggestions.test.ts
@@ -31,6 +31,17 @@ describe("suggestContacts", () => {
     ).toEqual(["zara@example.com", "sam@example.com", "person-alex@example.com"])
   })
 
+  it("filters invalid email-like contact values", () => {
+    const contactsWithInvalidEmail = [
+      contact("tristan@example.com", "Tristan", 10),
+      contact("/andm3ndgynjj5ndm3ndgynkmkgsbdxwst...", "Tristan", 8),
+    ]
+
+    expect(suggestContacts(contactsWithInvalidEmail, "tristan", []).map((c) => c.email)).toEqual([
+      "tristan@example.com",
+    ])
+  })
+
   it("keeps backend order within the same rank and respects limit", () => {
     expect(suggestContacts(contacts, "@example", [], 2).map((c) => c.email)).toEqual([
       "zara@example.com",

--- a/src/lib/contact-suggestions.test.ts
+++ b/src/lib/contact-suggestions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import type { Contact } from "@/rpc/bindings"
+
+import { suggestContacts } from "./contact-suggestions"
+
+const contacts: Contact[] = [
+  contact("zara@example.com", "Zara Zee", 10),
+  contact("alex@example.com", "Jordan Smith", 8),
+  contact("sam@example.com", "Alex Cooper", 6),
+  contact("person-alex@example.com", "Casey Example", 4),
+]
+
+describe("suggestContacts", () => {
+  it("returns no suggestions for an empty query", () => {
+    expect(suggestContacts(contacts, "", [])).toEqual([])
+    expect(suggestContacts(contacts, "   ", [])).toEqual([])
+  })
+
+  it("ranks email and name-word prefixes before substrings", () => {
+    expect(suggestContacts(contacts, "alex", []).map((c) => c.email)).toEqual([
+      "alex@example.com",
+      "sam@example.com",
+      "person-alex@example.com",
+    ])
+  })
+
+  it("excludes already-used emails case-insensitively", () => {
+    expect(
+      suggestContacts(contacts, "@example", [" ALEX@example.com "]).map((c) => c.email),
+    ).toEqual(["zara@example.com", "sam@example.com", "person-alex@example.com"])
+  })
+
+  it("keeps backend order within the same rank and respects limit", () => {
+    expect(suggestContacts(contacts, "@example", [], 2).map((c) => c.email)).toEqual([
+      "zara@example.com",
+      "alex@example.com",
+    ])
+  })
+})
+
+function contact(email: string, name: string, count: number): Contact {
+  return { email, name, count, last_seen: "2026-01-01" }
+}

--- a/src/lib/contact-suggestions.ts
+++ b/src/lib/contact-suggestions.ts
@@ -1,5 +1,7 @@
 import type { Contact } from "@/rpc/bindings"
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 export function suggestContacts(
   contacts: Contact[],
   query: string,
@@ -19,7 +21,9 @@ export function suggestContacts(
     }))
     .filter(
       (item): item is { contact: Contact; index: number; rank: number } =>
-        item.rank !== null && !excluded.has(normalizeEmail(item.contact.email)),
+        item.rank !== null &&
+        isValidContactEmail(item.contact.email) &&
+        !excluded.has(normalizeEmail(item.contact.email)),
     )
     .sort((a, b) => a.rank - b.rank || a.index - b.index)
     .slice(0, limit)
@@ -43,6 +47,10 @@ function matchRank(contact: Contact, query: string): number | null {
 
 function nameWords(name: string): string[] {
   return name.split(/\s+/).filter(Boolean)
+}
+
+export function isValidContactEmail(email: string): boolean {
+  return EMAIL_RE.test(normalizeEmail(email))
 }
 
 function normalizeEmail(email: string): string {

--- a/src/lib/contact-suggestions.ts
+++ b/src/lib/contact-suggestions.ts
@@ -1,0 +1,50 @@
+import type { Contact } from "@/rpc/bindings"
+
+export function suggestContacts(
+  contacts: Contact[],
+  query: string,
+  excludeEmails: Iterable<string>,
+  limit = 8,
+): Contact[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) return []
+
+  const excluded = new Set(Array.from(excludeEmails, normalizeEmail).filter(Boolean))
+
+  return contacts
+    .map((contact, index) => ({
+      contact,
+      index,
+      rank: matchRank(contact, normalizedQuery),
+    }))
+    .filter(
+      (item): item is { contact: Contact; index: number; rank: number } =>
+        item.rank !== null && !excluded.has(normalizeEmail(item.contact.email)),
+    )
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .slice(0, limit)
+    .map((item) => item.contact)
+}
+
+function matchRank(contact: Contact, query: string): number | null {
+  const email = contact.email.toLowerCase()
+  const name = contact.name?.toLowerCase() ?? ""
+
+  if (email.startsWith(query) || nameWords(name).some((word) => word.startsWith(query))) {
+    return 0
+  }
+
+  if (email.includes(query) || name.includes(query)) {
+    return 1
+  }
+
+  return null
+}
+
+function nameWords(name: string): string[] {
+  return name.split(/\s+/).filter(Boolean)
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -13,6 +13,8 @@ export type CalendarEvent = { id: string; recurring_event_id: string | null; sum
  */
 updated: string | null }
 
+export type Contact = { email: string; name: string | null; count: number; last_seen: string }
+
 /**
  * Input for creating an event
  */
@@ -104,7 +106,7 @@ export type UpdateEventInput = { id: string; calendar_slug: string;
  */
 new_calendar_slug: string | null; summary: string; description: string | null; location: string | null; start: RpcEventTime; end: RpcEventTime; recurrence: RpcRecurrence | null; reminders: number[]; attendees: EventAttendee[] }
 
-const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_groups":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_groups":["groups"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}', 'themes':'{"list_external":[]}' }
+const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_contacts":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_groups":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_groups":["groups"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[]}', 'themes':'{"list_external":[]}' }
 export type Router = { "caldir": {check_provider_connection: (providerName: string, account: string) => Promise<null>, 
 connect_provider: (providerName: string) => Promise<Calendar[]>, 
 connect_provider_with_credentials: (providerName: string, credentials: CredentialFieldInput[]) => Promise<Calendar[]>, 
@@ -120,6 +122,7 @@ get_event: (calendarSlug: string, eventId: string) => Promise<CalendarEvent | nu
 get_provider_connect_info: (providerName: string) => Promise<ProviderConnectInfo>, 
 get_time_format: () => Promise<TimeFormat>, 
 list_calendars: () => Promise<Calendar[]>, 
+list_contacts: () => Promise<Contact[]>, 
 list_events: (calendarSlugs: string[], start: string, end: string) => Promise<CalendarEvent[]>, 
 list_invites: (calendarSlugs: string[]) => Promise<CalendarEvent[]>, 
 list_providers: () => Promise<string[]>, 

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -62,10 +62,12 @@ These are the variables theme files override. Everything else (`--hover`, `--car
 
 The derived tokens (`--hover`, `--secondary`, `--accent`, `--card`, `--divider`, `--input`, …) are all built by mixing `--hover-tint` into progressively heavier layers. Tuning these two primitives is usually enough to match a theme's palette.
 
-| Variable       | Purpose                                                           |
-| -------------- | ----------------------------------------------------------------- |
-| `--hover-tint` | Color mixed over the background to produce hover / surface layers |
-| `--hover-mix`  | Percentage of tint per layer (each derived token adds one more)   |
+| Variable         | Purpose                                                           |
+| ---------------- | ----------------------------------------------------------------- |
+| `--hover-tint`   | Color mixed over the background to produce hover / surface layers |
+| `--hover-mix`    | Percentage of tint per layer (each derived token adds one more)   |
+| `--popover-tint` | Popover depth tint (`black` for dark themes, `white` for light)   |
+| `--popover-mix`  | Percentage of popover tint mixed into the background              |
 
 ### Structure
 

--- a/src/themes/catpuccin-latte.css
+++ b/src/themes/catpuccin-latte.css
@@ -13,6 +13,7 @@
 
 --hover-tint: #484f7f;
 --hover-mix: 10%;
+--popover-tint: white;
 
 --primary: var(--theme-lavender);
 --today: var(--theme-blue);


### PR DESCRIPTION
renCal already maintains an in-memory index of the user’s events.

This PR reuses that index to build a list of contacts from previous event attendees.

When the user types in the “Add attendee” input, renCal can search that indexed contact list and suggest matching attendees.

<img width="576" height="340" alt="image" src="https://github.com/user-attachments/assets/6de4cea0-4253-4e50-8d9f-f8931550f64f" />
