### PR TITLE
Bugfix: "a" should always create event on selected day

### DIFF
--- a/src/lib/active-day-draft.test.ts
+++ b/src/lib/active-day-draft.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import type { CalendarEvent } from "@/lib/cal-events"
+import { computeEventDateInfo, fromDate, toViewerZonedDateTime } from "@/lib/event-time"
+
+import { getLastEventEndTime } from "./active-day-draft"
+
+function eventBetween(startDate: Date, endDate: Date): CalendarEvent {
+  const start = fromDate(startDate)
+  const end = fromDate(endDate)
+  return {
+    id: "event",
+    recurring_event_id: null,
+    summary: "Late event",
+    description: null,
+    location: null,
+    start,
+    end,
+    status: "confirmed",
+    recurrence: null,
+    master_recurrence: null,
+    reminders: [],
+    organizer: null,
+    attendees: [],
+    conference_url: null,
+    calendar_slug: "calendar",
+    color: null,
+    updated: null,
+    dateInfo: computeEventDateInfo(start, end),
+  }
+}
+
+describe("getLastEventEndTime", () => {
+  it("falls back to 08:00 on the selected day when the last event ends at midnight", () => {
+    const selectedDay = new Date(2025, 6, 18, 12)
+    const event = eventBetween(new Date(2025, 6, 18, 22), new Date(2025, 6, 19, 0))
+
+    const suggestedStart = getLastEventEndTime(selectedDay, [event])
+    expect(suggestedStart).not.toBeNull()
+
+    const wallclock = toViewerZonedDateTime(suggestedStart!)
+    expect([
+      wallclock.year,
+      wallclock.month,
+      wallclock.day,
+      wallclock.hour,
+      wallclock.minute,
+    ]).toEqual([2025, 7, 18, 8, 0])
+  })
+})

--- a/src/lib/active-day-draft.ts
+++ b/src/lib/active-day-draft.ts
@@ -1,7 +1,7 @@
-import { startOfDay } from "date-fns"
+import { setHours, startOfDay } from "date-fns"
 
 import type { CalendarEvent } from "@/lib/cal-events"
-import type { EventTime } from "@/lib/event-time"
+import { fromDate, type EventTime } from "@/lib/event-time"
 import { isSpanning } from "@/lib/event-utils"
 
 /** DOM id on the active day's cell/column; anchors the new-event popover. */
@@ -9,14 +9,19 @@ export const ACTIVE_DAY_EL_ID = "active-day"
 
 /**
  * The end time of `date`'s last timed event, or null if it has none. A new event
- * on that day starts here so it follows the day's existing events. Shared by the
- * month "Create event" action and the "add event on active day" shortcut.
+ * on that day starts here so it follows the day's existing events. If that end
+ * is midnight on the next day, fall back to 08:00 on the selected day instead.
+ * Shared by the month "Create event" action and the "add event on active day"
+ * shortcut.
  */
 export function getLastEventEndTime(date: Date, events: CalendarEvent[]): EventTime | null {
-  const dayMs = startOfDay(date).getTime()
+  const day = startOfDay(date)
+  const dayMs = day.getTime()
   const last = events
     .filter((e) => !isSpanning(e) && e.dateInfo.firstDayMs === dayMs)
     .sort((a, b) => a.dateInfo.startMs - b.dateInfo.startMs)
     .at(-1)
-  return last ? last.end : null
+
+  if (!last) return null
+  return last.dateInfo.endDayMs === dayMs ? last.end : fromDate(setHours(day, 8))
 }


### PR DESCRIPTION
This fixes an edge-case where hitting "a" ("add event") would sometimes create an event for the *next* day, instead of the currently selected day.

This could happen if the currently selected day already had events going on until midnight. Since "a" tries to append at the end of the list, it would schedule the next event to be after 00:00.

This fixes this by detecting that edge-case and defaulting back to 8am for the same day.