### PR TITLE
Skip events with unparseable timezones

### DIFF
--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -12,7 +12,7 @@ import { useSettings } from "@/contexts/SettingsContext"
 import { useSync } from "@/contexts/SyncContext"
 
 import { useBreakpoint } from "@/hooks/useBreakpoint"
-import { eventKey, rpcToCalendarEvent, type CalendarEvent } from "@/lib/cal-events"
+import { eventKey, rpcToCalendarEvents, type CalendarEvent } from "@/lib/cal-events"
 import { formatTime, toInteropDate } from "@/lib/event-time"
 import { cn } from "@/lib/utils"
 
@@ -26,7 +26,7 @@ export function InvitesBadge() {
 
     rpc.caldir
       .list_invites(slugs)
-      .then((events) => setInvites(events.map(rpcToCalendarEvent)))
+      .then((events) => setInvites(rpcToCalendarEvents(events)))
       .catch(console.error)
   }, [calendars])
 

--- a/src/components/toolbar/search/SearchBar.tsx
+++ b/src/components/toolbar/search/SearchBar.tsx
@@ -8,7 +8,7 @@ import { useCalendars } from "@/contexts/CalendarStateContext"
 
 import { useDebouncedEffect } from "@/hooks/useDebouncedEffect"
 import { useOnClickOutside } from "@/hooks/useOnClickOutside"
-import { rpcToCalendarEvent, type CalendarEvent } from "@/lib/cal-events"
+import { rpcToCalendarEvents, type CalendarEvent } from "@/lib/cal-events"
 import { getCalendarColor } from "@/lib/calendar-styles"
 
 import { EventPopover } from "./EventPopover"
@@ -102,7 +102,7 @@ export function SearchBar({
 
       setIsLoading(true)
       void rpc.caldir.search_events(calendarSlugs, query).then((found) => {
-        setResults(found.map(rpcToCalendarEvent))
+        setResults(rpcToCalendarEvents(found))
         setIsLoading(false)
       })
     },

--- a/src/lib/cal-events-range.ts
+++ b/src/lib/cal-events-range.ts
@@ -3,7 +3,7 @@ import { addMonths, endOfMonth, startOfMonth, subMonths } from "date-fns"
 
 import { rpc } from "@/rpc"
 
-import { eventKey, rpcToCalendarEvent, type CalendarEvent } from "@/lib/cal-events"
+import { eventKey, rpcToCalendarEvents, type CalendarEvent } from "@/lib/cal-events"
 import { DateRange } from "@/lib/types"
 
 export const MONTHS_TO_LOAD = 2
@@ -46,5 +46,5 @@ export async function getCalendarEventsForRange(
     dateToUtcInstant(start),
     dateToUtcInstant(end),
   )
-  return events.map(rpcToCalendarEvent)
+  return rpcToCalendarEvents(events)
 }

--- a/src/lib/cal-events.ts
+++ b/src/lib/cal-events.ts
@@ -9,6 +9,8 @@
  * day, and place events without round-tripping through Temporal on every
  * render.
  */
+import { toast } from "sonner"
+
 import type { CalendarEvent as RpcCalendarEvent, RpcRecurrence } from "@/rpc/bindings"
 
 import { computeEventDateInfo, type EventDateInfo, type EventTime } from "./event-time"
@@ -59,6 +61,33 @@ export function rpcToCalendarEvent(w: RpcCalendarEvent): CalendarEvent {
     recurrence: w.recurrence ? rpcToRecurrence(w.recurrence) : null,
     master_recurrence: w.master_recurrence ? rpcToRecurrence(w.master_recurrence) : null,
   }
+}
+
+// Events whose skip warning has already been toasted this session, so periodic
+// reloads of the same broken event don't re-warn on every sync.
+const warnedSkippedEventKeys = new Set<string>()
+
+/**
+ * Convert a batch of RPC events, skipping any that fail to parse (e.g. a
+ * non-IANA TZID like "GMT+0100" from an external sync) instead of rejecting
+ * the whole load. Each skipped event is reported once per session as a toast.
+ */
+export function rpcToCalendarEvents(rpcEvents: RpcCalendarEvent[]): CalendarEvent[] {
+  const converted: CalendarEvent[] = []
+  for (const rpcEvent of rpcEvents) {
+    try {
+      converted.push(rpcToCalendarEvent(rpcEvent))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn(`Skipping event "${rpcEvent.summary}" (${eventKey(rpcEvent)}): ${message}`)
+      const key = eventKey(rpcEvent)
+      if (!warnedSkippedEventKeys.has(key)) {
+        warnedSkippedEventKeys.add(key)
+        toast.warning(`Couldn't display "${rpcEvent.summary}"`, { description: message })
+      }
+    }
+  }
+  return converted
 }
 
 export function calendarEventToRpc(e: CalendarEvent): RpcCalendarEvent {

--- a/src/lib/cal-events.ts
+++ b/src/lib/cal-events.ts
@@ -9,8 +9,6 @@
  * day, and place events without round-tripping through Temporal on every
  * render.
  */
-import { toast } from "sonner"
-
 import type { CalendarEvent as RpcCalendarEvent, RpcRecurrence } from "@/rpc/bindings"
 
 import { computeEventDateInfo, type EventDateInfo, type EventTime } from "./event-time"
@@ -63,14 +61,10 @@ export function rpcToCalendarEvent(w: RpcCalendarEvent): CalendarEvent {
   }
 }
 
-// Events whose skip warning has already been toasted this session, so periodic
-// reloads of the same broken event don't re-warn on every sync.
-const warnedSkippedEventKeys = new Set<string>()
-
 /**
  * Convert a batch of RPC events, skipping any that fail to parse (e.g. a
  * non-IANA TZID like "GMT+0100" from an external sync) instead of rejecting
- * the whole load. Each skipped event is reported once per session as a toast.
+ * the whole load.
  */
 export function rpcToCalendarEvents(rpcEvents: RpcCalendarEvent[]): CalendarEvent[] {
   const converted: CalendarEvent[] = []
@@ -80,11 +74,6 @@ export function rpcToCalendarEvents(rpcEvents: RpcCalendarEvent[]): CalendarEven
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.warn(`Skipping event "${rpcEvent.summary}" (${eventKey(rpcEvent)}): ${message}`)
-      const key = eventKey(rpcEvent)
-      if (!warnedSkippedEventKeys.has(key)) {
-        warnedSkippedEventKeys.add(key)
-        toast.warning(`Couldn't display "${rpcEvent.summary}"`, { description: message })
-      }
     }
   }
   return converted


### PR DESCRIPTION
Ran into a nasty bug where the app completely breaks (shows no data) if it encounters an event with a timezone it can't parse:

<img width="1504" height="832" alt="image" src="https://github.com/user-attachments/assets/07e352ea-a6ab-4973-ba6d-7b9d48de5683" />

We should now just skip those events and log a warning. ✅

A more thorough fix for parsing weird timezones will be implemented in `caldir-core`
