### PR TITLE
Tweak settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ src-tauri/providers/
 
 # Local cargo config (path overrides for sibling caldir checkout)
 .cargo/
+
+# Flatpak build output
+build-dir/
+.flatpak-builder/

--- a/src/components/settings/SettingsSidebar.tsx
+++ b/src/components/settings/SettingsSidebar.tsx
@@ -40,7 +40,7 @@ export function SettingsSidebar({
   onTabChange: (tab: SettingsTab) => void
 }) {
   return (
-    <nav className="flex flex-col gap-1 w-[200px] shrink-0 py-5 px-4 border-r border-r-divider">
+    <nav className="flex flex-col gap-1 w-[200px] shrink-0 py-3 px-2 border-r border-r-divider">
       {NAV_ITEMS.map((item) => (
         <SidebarItem
           key={item.tab}

--- a/src/components/settings/accounts/AccountsPage.tsx
+++ b/src/components/settings/accounts/AccountsPage.tsx
@@ -53,7 +53,7 @@ export function AccountsPage() {
   }
 
   return (
-    <SettingsContent className="py-6 w-[400px]">
+    <SettingsContent className="w-[400px]">
       {!!accounts.length && (
         <div className="flex flex-col gap-4">
           {accounts.map(({ account, provider }) => (
@@ -150,7 +150,7 @@ function Account({
       <div className="flex flex-col gap-0.5 flex-1 min-w-0">
         <span className="heading text-sm">{displayName}</span>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild tabIndex={-1}>
               <span

--- a/src/components/settings/calendars/CalendarsColumn.tsx
+++ b/src/components/settings/calendars/CalendarsColumn.tsx
@@ -72,7 +72,7 @@ export function CalendarsColumn({ selectedGroup }: { selectedGroup: string }) {
   const calendarsByProvider = Object.groupBy(remoteCalendars, (c) => c.provider as string)
 
   return (
-    <SettingsContent className="grow py-7">
+    <SettingsContent className="grow py-5">
       {!!calendars.length && (
         <div className="flex flex-col gap-4">
           {Object.entries(calendarsByProvider).map(([provider, cals]) => (

--- a/src/components/settings/calendars/GroupsColumn.tsx
+++ b/src/components/settings/calendars/GroupsColumn.tsx
@@ -66,7 +66,7 @@ export function GroupsColumn({
   }
 
   return (
-    <SettingsContent className="w-[220px] border-r border-r-divider gap-2 py-6 grow-0">
+    <SettingsContent className="w-[220px] border-r border-r-divider gap-2 py-[15px] grow-0">
       <div className="flex justify-between items-center w-full">
         <span className="text-sm text-muted-foreground">Groups</span>
 

--- a/src/components/settings/calendars/GroupsColumn.tsx
+++ b/src/components/settings/calendars/GroupsColumn.tsx
@@ -66,9 +66,9 @@ export function GroupsColumn({
   }
 
   return (
-    <SettingsContent className="w-[220px] border-r border-r-divider gap-2 py-[15px] grow-0">
+    <SettingsContent className="w-[220px] border-r border-r-divider gap-2 py-[15px] grow-0 px-2">
       <div className="flex justify-between items-center w-full">
-        <span className="text-sm text-muted-foreground">Groups</span>
+        <span className="text-sm text-muted-foreground pl-1 heading">Groups</span>
 
         <Button size="icon-sm" variant="ghost" onClick={() => setModalState({ mode: "create" })}>
           <PlusIcon className="size-4" />
@@ -89,7 +89,7 @@ export function GroupsColumn({
                 if (event.key === "Enter" || event.key === " ") onSelect(group)
               }}
               className={cn(
-                "text-sm flex items-center justify-between gap-2 rounded-md text-muted-foreground px-3 py-2 group text-left cursor-pointer",
+                "text-sm flex items-center justify-between gap-2 rounded-md text-muted-foreground px-2 py-2 group text-left cursor-pointer",
                 {
                   "bg-secondary text-accent-foreground": selectedGroup === group,
                 },

--- a/src/components/settings/general/GeneralPage.tsx
+++ b/src/components/settings/general/GeneralPage.tsx
@@ -57,8 +57,8 @@ const AutoSyncSection = () => {
   const id = useId()
 
   return (
-    <div className="flex flex-col gap-2 w-[400px]">
-      <div className="flex items-center gap-3">
+    <div className="flex flex-col gap-1 w-[400px]">
+      <div className="flex items-center gap-2">
         <Checkbox
           id={id}
           checked={autoSyncEnabled}

--- a/src/components/settings/reminders/RemindersPage.tsx
+++ b/src/components/settings/reminders/RemindersPage.tsx
@@ -9,7 +9,7 @@ import { useSettings } from "@/contexts/SettingsContext"
 
 export function RemindersPage() {
   return (
-    <SettingsContent className="py-7">
+    <SettingsContent>
       <NotificationsSection />
       <DefaultRemindersSection />
     </SettingsContent>

--- a/src/components/settings/themes/ThemesPage.tsx
+++ b/src/components/settings/themes/ThemesPage.tsx
@@ -12,7 +12,7 @@ export function ThemesPage() {
   const { descriptors } = useThemeRegistry()
 
   return (
-    <SettingsContent className="w-full mr-6 py-6">
+    <SettingsContent className="w-full">
       <ThemeGrid themes={descriptors} active={theme} onSelect={setTheme} />
     </SettingsContent>
   )

--- a/src/components/settings/themes/ThemesPage.tsx
+++ b/src/components/settings/themes/ThemesPage.tsx
@@ -1,7 +1,7 @@
 import { SettingsContent } from "@/components/settings/SettingsContent"
 
 import { useTheme } from "@/hooks/useTheme"
-import { cn } from "@/lib/utils"
+import { cn, isMacOS } from "@/lib/utils"
 
 import { CheckIcon } from "@/icons/check"
 import { useThemeRegistry } from "@/themes/ThemeRegistry"
@@ -12,7 +12,7 @@ export function ThemesPage() {
   const { descriptors } = useThemeRegistry()
 
   return (
-    <SettingsContent className="w-full">
+    <SettingsContent className={cn("w-full", { "pt-8": !isMacOS })}>
       <ThemeGrid themes={descriptors} active={theme} onSelect={setTheme} />
     </SettingsContent>
   )

--- a/src/windows/SettingsWindow.tsx
+++ b/src/windows/SettingsWindow.tsx
@@ -32,11 +32,11 @@ export function SettingsWindow() {
 
   const activeItem = NAV_ITEMS.find((item) => item.tab === activeTab)
   if (!activeItem) return null
-  const { label, page: ActivePage } = activeItem
+  const { page: ActivePage } = activeItem
 
   return (
-    <div className={cn("flex h-screen", { "pt-8": isMacOS })}>
-      <DragRegion className="absolute top-0 left-0 right-0 h-5!" />
+    <div className={cn("flex flex-col h-screen", { "pt-7": isMacOS })}>
+      <DragRegion className="absolute top-0 left-0 right-0 h-7! border-b border-b-divider" />
 
       <ShortcutTooltip text="Close" shortcut="escape">
         <button
@@ -45,16 +45,21 @@ export function SettingsWindow() {
               .close()
               .catch(() => {})
           }
-          className="absolute top-2 right-2 z-50 rounded-sm p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring"
+          className={cn(
+            "absolute top-[3px] right-2 z-50 rounded-sm p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring",
+            { hidden: isMacOS },
+          )}
           aria-label="Close"
         >
           <CloseIcon className="size-4" />
         </button>
       </ShortcutTooltip>
 
-      <SettingsSidebar activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="flex h-screen">
+        <SettingsSidebar activeTab={activeTab} onTabChange={setActiveTab} />
 
-      <ActivePage />
+        <ActivePage />
+      </div>
     </div>
   )
 }

--- a/src/windows/SettingsWindow.tsx
+++ b/src/windows/SettingsWindow.tsx
@@ -36,7 +36,11 @@ export function SettingsWindow() {
 
   return (
     <div className={cn("flex flex-col h-screen", { "pt-7": isMacOS })}>
-      <DragRegion className="absolute top-0 left-0 right-0 h-7! border-b border-b-divider" />
+      <DragRegion
+        className={cn("absolute top-0 left-0 right-0 h-7! border-b border-b-divider", {
+          hidden: !isMacOS,
+        })}
+      />
 
       <ShortcutTooltip text="Close" shortcut="escape">
         <button

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,8 @@ export default defineConfig(async () => ({
       : undefined,
     watch: {
       // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+      // flatpak dirs contain symlinks into /run that crash the watcher
+      ignored: ["**/src-tauri/**", "**/build-dir/**", "**/.flatpak-builder/**"],
     },
   },
 }))


### PR DESCRIPTION
Some subtle changes to remove the excessive padding in the Settings modal.

Also adds a divider line at the top of the modal on macOS to make it look more natural.

*Before:*

<img width="1698" height="1070" alt="CleanShot 2026-07-23 at 17 47 30@2x" src="https://github.com/user-attachments/assets/f2141f32-a4bc-4def-9c90-df58bbf8e23d" />

*After:*

<img width="1722" height="1068" alt="CleanShot 2026-07-23 at 17 46 38@2x" src="https://github.com/user-attachments/assets/f1740b3d-0142-4b91-9150-b976549a3d52" />
