### PR TITLE
Handle conference links in "Location" field

### DIFF
--- a/src/components/event-parts/EventInfo.tsx
+++ b/src/components/event-parts/EventInfo.tsx
@@ -132,6 +132,7 @@ export function EventInfo({
 
         <ConferenceDisplay
           conference={conference}
+          location={location}
           calendar={calendar}
           readonly={readonly}
           onConferenceChange={onConferenceChange}

--- a/src/components/event-parts/inputs/ConferenceDisplay.tsx
+++ b/src/components/event-parts/inputs/ConferenceDisplay.tsx
@@ -38,9 +38,9 @@ export function ConferenceDisplay({
   onConferenceChange?: (conference: EventConference | null) => void
 }) {
   if (conference?.status === "live") {
-    return (
-      <ConferenceLink url={conference.url} label={conferenceLabel[conference.provider]} showUrl />
-    )
+    const label = conferenceLabel[conference.provider]
+
+    return <ConferenceLink url={conference.url} label={label} showUrl />
   }
 
   if (conference?.status === "requested") {

--- a/src/components/event-parts/inputs/ConferenceDisplay.tsx
+++ b/src/components/event-parts/inputs/ConferenceDisplay.tsx
@@ -40,7 +40,7 @@ export function ConferenceDisplay({
   if (conference?.status === "live") {
     const label = conferenceLabel[conference.provider]
 
-    return <ConferenceLink url={conference.url} label={label} showUrl />
+    return <ConferenceLink url={conference.url} label={label} />
   }
 
   if (conference?.status === "requested") {
@@ -74,22 +74,14 @@ export function ConferenceDisplay({
   return null
 }
 
-function ConferenceLink({
-  url,
-  label,
-  showUrl,
-}: {
-  url: string
-  label: string
-  showUrl?: boolean
-}) {
+function ConferenceLink({ url, label }: { url: string; label: string }) {
   return (
     <div className="flex flex-col gap-1 px-3 py-1">
       <Button className="w-full" onClick={() => openUrl(url)}>
         <VideoIcon />
         Join {label}
       </Button>
-      {showUrl && <span className="text-xs text-muted-foreground truncate px-1">{url}</span>}
+      <span className="text-xs text-muted-foreground truncate px-1">{url}</span>
     </div>
   )
 }

--- a/src/components/event-parts/inputs/ConferenceDisplay.tsx
+++ b/src/components/event-parts/inputs/ConferenceDisplay.tsx
@@ -8,6 +8,7 @@ import type { Calendar } from "@/rpc/bindings"
 import {
   calendarConferenceProvider,
   conferenceLabel,
+  detectConference,
   type ConferenceProvider,
   type EventConference,
 } from "@/lib/conference"
@@ -25,17 +26,21 @@ const conferenceIcon: Record<ConferenceProvider, React.ComponentType<{ className
 
 export function ConferenceDisplay({
   conference,
+  location,
   calendar,
   readonly,
   onConferenceChange,
 }: {
   conference?: EventConference | null
+  location?: string | null
   calendar?: Calendar
   readonly?: boolean
   onConferenceChange?: (conference: EventConference | null) => void
 }) {
   if (conference?.status === "live") {
-    return <ConferenceLink conference={conference} />
+    return (
+      <ConferenceLink url={conference.url} label={conferenceLabel[conference.provider]} showUrl />
+    )
   }
 
   if (conference?.status === "requested") {
@@ -46,6 +51,13 @@ export function ConferenceDisplay({
         onRemove={onConferenceChange ? () => onConferenceChange(null) : undefined}
       />
     )
+  }
+
+  // Conference links detected in event's "Location" field:
+  const detected = detectConference(location)
+
+  if (detected) {
+    return <ConferenceLink url={detected.url} label={detected.label} />
   }
 
   const conferenceProvider = calendarConferenceProvider(calendar)
@@ -63,17 +75,21 @@ export function ConferenceDisplay({
 }
 
 function ConferenceLink({
-  conference,
+  url,
+  label,
+  showUrl,
 }: {
-  conference: Extract<EventConference, { status: "live" }>
+  url: string
+  label: string
+  showUrl?: boolean
 }) {
   return (
     <div className="flex flex-col gap-1 px-3 py-1">
-      <Button className="w-full" onClick={() => openUrl(conference.url)}>
+      <Button className="w-full" onClick={() => openUrl(url)}>
         <VideoIcon />
-        Join {conferenceLabel[conference.provider]}
+        Join {label}
       </Button>
-      <span className="text-xs text-muted-foreground truncate px-1">{conference.url}</span>
+      {showUrl && <span className="text-xs text-muted-foreground truncate px-1">{url}</span>}
     </div>
   )
 }

--- a/src/lib/conference.test.ts
+++ b/src/lib/conference.test.ts
@@ -6,6 +6,7 @@ import {
   calendarConferenceProvider,
   conferenceForCalendar,
   conferenceToRpc,
+  detectConference,
   rpcToConference,
   type EventConference,
 } from "@/lib/conference"
@@ -44,6 +45,45 @@ describe("conferenceForCalendar", () => {
     }
 
     expect(conferenceForCalendar(live, calendar("google"))).toEqual(live)
+  })
+})
+
+describe("detectConference", () => {
+  it.each([
+    ["https://us02web.zoom.us/j/123456789?pwd=abc123", "Zoom"],
+    ["https://company.zoom.us/my/room", "Zoom"],
+    ["https://meet.google.com/abc-defg-hij", "Google Meet"],
+    ["https://teams.microsoft.com/l/meetup-join/xyz", "Microsoft Teams"],
+    ["https://teams.live.com/meet/123", "Microsoft Teams"],
+    ["https://company.webex.com/meet/someone", "Webex"],
+    ["https://meet.jit.si/SomeRoom", "Jitsi"],
+    ["https://whereby.com/some-room", "Whereby"],
+    ["https://meet.proton.me/example", "Proton Meet"],
+  ])("detects %s as %s", (url, label) => {
+    expect(detectConference(url)).toEqual({ url, label })
+  })
+
+  it("extracts the link from surrounding text", () => {
+    expect(detectConference("Join here: https://zoom.us/j/99887766 (passcode 1234)")).toEqual({
+      url: "https://zoom.us/j/99887766",
+      label: "Zoom",
+    })
+  })
+
+  it("trims trailing punctuation from the link", () => {
+    expect(detectConference("(https://meet.google.com/abc-defg-hij)")).toEqual({
+      url: "https://meet.google.com/abc-defg-hij",
+      label: "Google Meet",
+    })
+  })
+
+  it("ignores locations without a meeting link", () => {
+    expect(detectConference("Room 4B, Main Office")).toBeNull()
+    expect(detectConference("https://zoom.us")).toBeNull()
+    expect(detectConference("https://example.com/zoom.us/j/123")).toBeNull()
+    expect(detectConference("")).toBeNull()
+    expect(detectConference(null)).toBeNull()
+    expect(detectConference(undefined)).toBeNull()
   })
 })
 

--- a/src/lib/conference.ts
+++ b/src/lib/conference.ts
@@ -16,6 +16,31 @@ export const conferenceLabel: Record<ConferenceProvider, string> = {
   proton: "Meeting",
 }
 
+/** A meeting link found in free-form event text, unlike a stored `EventConference`. */
+export type DetectedConference = { url: string; label: string }
+
+const meetingUrlPatterns: [label: string, pattern: RegExp][] = [
+  ["Zoom", /https?:\/\/(?:[\w-]+\.)*(?:zoom\.us|zoomgov\.com)\/(?:j|my|s|w|wc)\/[^\s<>"']+/i],
+  ["Google Meet", /https?:\/\/meet\.google\.com\/[^\s<>"']+/i],
+  ["Microsoft Teams", /https?:\/\/teams\.(?:microsoft|live)\.com\/[^\s<>"']+/i],
+  ["Webex", /https?:\/\/(?:[\w-]+\.)*webex\.com\/[^\s<>"']+/i],
+  ["Jitsi", /https?:\/\/meet\.jit\.si\/[^\s<>"']+/i],
+  ["Whereby", /https?:\/\/(?:www\.)?whereby\.com\/[^\s<>"']+/i],
+  ["Proton Meet", /https?:\/\/meet\.proton\.me\/[^\s<>"']+/i],
+]
+
+/** Find a known meeting link in free-form text, e.g. an event location holding a Zoom URL. */
+export const detectConference = (text: string | null | undefined): DetectedConference | null => {
+  if (!text) return null
+
+  for (const [label, pattern] of meetingUrlPatterns) {
+    const match = text.match(pattern)
+    if (match) return { label, url: match[0].replace(/[),.;:!?\]]+$/, "") }
+  }
+
+  return null
+}
+
 /** The conference provider renCal can provision for events on this calendar, if any. */
 export const calendarConferenceProvider = (calendar?: Calendar): ConferenceProvider | null =>
   calendar?.provider === "google" ? "google" : null


### PR DESCRIPTION
Some events don't have a special `CONFERENCE` property.

Events with a Zoom conference for example usually just add the Zoom link as the event's "location".

This PR detects links from well-known video conference providers in the location field and renders as "Join meeting" button, similar to events with a Google Meet.

<img width="876" height="256" alt="image" src="https://github.com/user-attachments/assets/0ebc51f0-61d6-46c8-9a02-8ed63125ac44" />
