### PR TITLE
Bugfix: only show time row when necessary

### DIFF
--- a/src/components/event-parts/EventInfo.tsx
+++ b/src/components/event-parts/EventInfo.tsx
@@ -36,7 +36,6 @@ export function EventInfo({
   onChangeDateTime,
   allDay,
   onAllDayChange,
-  showTime,
   location,
   onLocationChange,
   calendar,
@@ -74,7 +73,6 @@ export function EventInfo({
   onRecurrenceChange: (recurrence: RRule | RRuleSet | null) => void
   calendar?: Calendar
   onCalendarChange: (calendarId: string) => void
-  showTime?: boolean
   description?: string | null
   onDescriptionChange: (description: string) => void
   organizer?: EventAttendee | null
@@ -119,13 +117,7 @@ export function EventInfo({
           readOnly={readonly}
         />
 
-        <DateTimeSelect
-          start={start}
-          end={end}
-          showTime={showTime}
-          readOnly={readonly}
-          onChange={onChangeDateTime}
-        />
+        <DateTimeSelect start={start} end={end} readOnly={readonly} onChange={onChangeDateTime} />
         <AllDayCheckbox checked={allDay} onCheckedChange={onAllDayChange} readOnly={readonly} />
 
         <RepeatSelect value={recurrence} onChange={onRecurrenceChange} readOnly={readonly} />

--- a/src/components/event-parts/inputs/DateTimeSelect.tsx
+++ b/src/components/event-parts/inputs/DateTimeSelect.tsx
@@ -31,19 +31,20 @@ const FIRST_INPUT_WIDTH = 140
 export const DateTimeSelect = ({
   start,
   end,
-  showTime = true,
   readOnly,
   onChange,
 }: {
   start: EventTime
   end: EventTime
-  showTime?: boolean
   readOnly?: boolean
   onChange: (range: DateTimeRange) => void
 }) => {
   const allDay = isAllDay(start)
   const lastTimedRange = useLastTimedRange(start, end)
-  const visibleTimeRange = allDay ? (lastTimedRange ?? { start, end }) : { start, end }
+  // An all-day event with no remembered timed range has no times to show —
+  // hide the time row entirely instead of rendering empty inputs.
+  const visibleTimeRange = allDay ? lastTimedRange : { start, end }
+  const timeRowVisible = visibleTimeRange !== null
 
   const handleStartTime = (hour: number, minute: number) =>
     onChange(withRangeStartWallclockTime({ start, end }, hour, minute))
@@ -63,7 +64,7 @@ export const DateTimeSelect = ({
 
   return (
     <div className="flex flex-col gap-1">
-      {showTime && (
+      {timeRowVisible && (
         <TimeSelect
           start={visibleTimeRange.start}
           end={visibleTimeRange.end}
@@ -77,6 +78,7 @@ export const DateTimeSelect = ({
         startDate={plainDateToLocalDate(dateInEventZone(start))}
         endDate={plainDateToLocalDate(displayEndDate({ start, end }))}
         showEndDate={shouldShowDisplayEndDate({ start, end })}
+        icon={timeRowVisible ? null : <ClockIcon />}
         readOnly={readOnly}
         onChangeStart={handleStartDate}
         onChangeEnd={handleEndDate}
@@ -133,6 +135,7 @@ const DateSelect = ({
   startDate,
   endDate,
   showEndDate,
+  icon,
   readOnly,
   onChangeStart,
   onChangeEnd,
@@ -140,6 +143,7 @@ const DateSelect = ({
   startDate: Date
   endDate: Date
   showEndDate: boolean
+  icon?: React.ReactNode
   readOnly?: boolean
   onChangeStart: (date: Date | null) => void
   onChangeEnd: (date: Date | null) => void
@@ -152,7 +156,7 @@ const DateSelect = ({
           width: FIRST_INPUT_WIDTH,
         }}
       >
-        <InputGroupAddon />
+        <InputGroupAddon>{icon}</InputGroupAddon>
         <DatePicker date={startDate} setDate={onChangeStart} readOnly={readOnly} />
       </div>
 


### PR DESCRIPTION
All-day events would get an ugly empty time row after being created:

**Before:**

<img width="784" height="614" alt="screenshot-2026-07-31_11-21-00" src="https://github.com/user-attachments/assets/4378b212-a334-4b71-b76f-2d0f6f7868f5" />

This PR automatically hides the time row for created events, until the user untoggles "All-day":

**After:**

<img width="780" height="516" alt="screenshot-2026-07-31_11-25-00" src="https://github.com/user-attachments/assets/3f303675-46f6-4f35-a805-f02da28ec333" />
