### PR TITLE
Stop using hand cursor for buttons

### DIFF
--- a/src/components/event-parts/inputs/AllDayCheckbox.tsx
+++ b/src/components/event-parts/inputs/AllDayCheckbox.tsx
@@ -28,7 +28,6 @@ export const AllDayCheckbox = ({
         <Checkbox
           id={id}
           checked={checked}
-          className="cursor-pointer"
           onCheckedChange={() => {
             onCheckedChange(!checked)
           }}
@@ -38,7 +37,7 @@ export const AllDayCheckbox = ({
 
       <Label
         htmlFor={id}
-        className={cn("cursor-pointer text-muted-foreground", {
+        className={cn("text-muted-foreground", {
           "text-sidebar-primary-foreground": checked,
         })}
       >

--- a/src/components/settings/calendars/CalendarsColumn.tsx
+++ b/src/components/settings/calendars/CalendarsColumn.tsx
@@ -168,10 +168,10 @@ export function TogglableCalendarItem({
           checked={checked}
           onCheckedChange={(value) => onCheckedChange(value === true)}
           style={calendarColorStyle}
-          className="cursor-pointer data-[state=checked]:border-[var(--calendar-color)] data-[state=checked]:bg-[var(--calendar-color)]"
+          className="data-[state=checked]:border-[var(--calendar-color)] data-[state=checked]:bg-[var(--calendar-color)]"
         />
 
-        <Label htmlFor={id} className="cursor-pointer text-sm text-foreground truncate">
+        <Label htmlFor={id} className="text-sm text-foreground truncate">
           {name || slug}
         </Label>
       </div>

--- a/src/components/settings/calendars/ChangeCalendarColorModal.tsx
+++ b/src/components/settings/calendars/ChangeCalendarColorModal.tsx
@@ -68,7 +68,7 @@ export function ChangeCalendarColorModal({
               value={hue}
               aria-label="Calendar color hue"
               onChange={(event) => changeHue(Number(event.target.value))}
-              className="h-3 w-full cursor-pointer appearance-none rounded-full bg-[linear-gradient(to_right,#e05252,#e0e052,#52e052,#52e0e0,#5252e0,#e052e0,#e05252)] [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:shadow-sm"
+              className="h-3 w-full appearance-none rounded-full bg-[linear-gradient(to_right,#e05252,#e0e052,#52e052,#52e0e0,#5252e0,#e052e0,#e05252)] [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:shadow-sm"
             />
           </div>
 

--- a/src/components/settings/calendars/GroupsColumn.tsx
+++ b/src/components/settings/calendars/GroupsColumn.tsx
@@ -89,7 +89,7 @@ export function GroupsColumn({
                 if (event.key === "Enter" || event.key === " ") onSelect(group)
               }}
               className={cn(
-                "text-sm flex items-center justify-between gap-2 rounded-md text-muted-foreground px-2 py-2 group text-left cursor-pointer",
+                "text-sm flex items-center justify-between gap-2 rounded-md text-muted-foreground px-2 py-2 group text-left",
                 {
                   "bg-secondary text-accent-foreground": selectedGroup === group,
                 },

--- a/src/components/settings/general/GeneralPage.tsx
+++ b/src/components/settings/general/GeneralPage.tsx
@@ -63,9 +63,8 @@ const AutoSyncSection = () => {
           id={id}
           checked={autoSyncEnabled}
           onCheckedChange={(checked) => void setAutoSyncEnabled(checked === true)}
-          className="cursor-pointer"
         />
-        <Label htmlFor={id} className="cursor-pointer text-sm">
+        <Label htmlFor={id} className="text-sm">
           Automatic sync
         </Label>
       </div>

--- a/src/components/settings/reminders/RemindersPage.tsx
+++ b/src/components/settings/reminders/RemindersPage.tsx
@@ -27,9 +27,8 @@ const NotificationsSection = () => {
           id={id}
           checked={notificationsEnabled}
           onCheckedChange={(checked) => void setNotificationsEnabled(checked === true)}
-          className="cursor-pointer"
         />
-        <Label htmlFor={id} className="cursor-pointer text-sm">
+        <Label htmlFor={id} className="text-sm">
           Enable notifications
         </Label>
       </div>

--- a/src/components/sidebar/header/compose-event/ComposeEventInput.tsx
+++ b/src/components/sidebar/header/compose-event/ComposeEventInput.tsx
@@ -77,6 +77,7 @@ export const ComposeEventInput = ({ onExit }: { onExit: () => void }) => {
         className={cn(
           "w-full",
           !isDrafting && "caret-transparent",
+          !showText && "hover:border-transparent hover:bg-secondary-hover",
           showText && displayText && "pr-9",
         )}
       />

--- a/src/components/sidebar/header/compose-event/ComposeEventInput.tsx
+++ b/src/components/sidebar/header/compose-event/ComposeEventInput.tsx
@@ -76,7 +76,7 @@ export const ComposeEventInput = ({ onExit }: { onExit: () => void }) => {
         }}
         className={cn(
           "w-full",
-          !isDrafting && "cursor-pointer caret-transparent",
+          !isDrafting && "caret-transparent",
           showText && displayText && "pr-9",
         )}
       />

--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -49,7 +49,7 @@ export function InvitesBadge() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button className="flex size-6 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white cursor-pointer hover:bg-red-600 transition-colors outline-none">
+        <button className="flex size-6 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white hover:bg-red-600 transition-colors outline-none">
           {invites.length}
         </button>
       </PopoverTrigger>

--- a/src/components/toolbar/ReportBugButton.tsx
+++ b/src/components/toolbar/ReportBugButton.tsx
@@ -13,7 +13,7 @@ export const ReportBugButton = () => {
           tabIndex={-1}
           variant="ghost"
           size="icon"
-          className="text-muted-foreground"
+          className="text-muted-foreground cursor-pointer"
           onClick={() => openUrl("https://github.com/t4t5/rencal/issues/new")}
         >
           <BugIcon className="size-5" />

--- a/src/components/toolbar/search/SearchButton.tsx
+++ b/src/components/toolbar/search/SearchButton.tsx
@@ -17,6 +17,7 @@ export function SearchButton() {
       <ShortcutTooltip text="Search" shortcut="/">
         <Button
           id={SEARCH_BUTTON_EL_ID}
+          size="icon"
           variant="secondary"
           tabIndex={-1}
           onClick={() => setOpen(true)}

--- a/src/components/toolbar/search/SearchPalette.tsx
+++ b/src/components/toolbar/search/SearchPalette.tsx
@@ -151,7 +151,7 @@ export function SearchPalette({
                   key={eventKey(event)}
                   value={eventKey(event)}
                   onSelect={() => selectEvent(event)}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5"
+                  className="flex items-center gap-2 px-3 py-1.5"
                 >
                   <SearchResultEventBlock
                     event={event}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium button transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive enabled:cursor-pointer select-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium button transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive select-none",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Makes the app feel more native. Hands should only be for external links.

See: https://adamsilver.io/blog/buttons-shouldnt-have-a-hand-cursor/