### PR TITLE
Tweak UX for readonly calendars

### DIFF
--- a/src/components/event-parts/EventInfo.tsx
+++ b/src/components/event-parts/EventInfo.tsx
@@ -14,7 +14,6 @@ import type { Calendar, EventAttendee, ResponseStatus } from "@/rpc/bindings"
 
 import type { EventConference } from "@/lib/conference"
 import type { EventTime } from "@/lib/event-time"
-import { cn } from "@/lib/utils"
 
 import { NotesInput } from "./inputs/NotesInput"
 import { RsvpBar } from "./inputs/RsvpBar"
@@ -97,10 +96,7 @@ export function EventInfo({
             ref={summaryRef}
             placeholder="Event Title"
             value={summary ?? ""}
-            className={cn(
-              "text-base font-medium",
-              readonly && "hover:border-transparent! focus:bg-transparent!",
-            )}
+            className="text-base font-medium"
             readOnly={readonly}
             onChange={(e) => onChangeSummary(e.target.value)}
             onKeyDown={(e) => {

--- a/src/components/event-parts/EventInfo.tsx
+++ b/src/components/event-parts/EventInfo.tsx
@@ -152,13 +152,11 @@ export function EventInfo({
           </>
         )}
 
-        {canEdit && !calendar?.read_only && (
-          <ReminderSelect
-            reminders={reminders ?? []}
-            onSelect={onReminderAdd}
-            onRemove={onReminderRemove}
-          />
-        )}
+        <ReminderSelect
+          reminders={reminders ?? []}
+          onSelect={onReminderAdd}
+          onRemove={onReminderRemove}
+        />
 
         <CalendarSelect calendar={calendar} onChange={onCalendarChange} readOnly={readonly} />
 

--- a/src/components/event-parts/EventInfo.tsx
+++ b/src/components/event-parts/EventInfo.tsx
@@ -87,40 +87,51 @@ export function EventInfo({
   userResponseStatus?: ResponseStatus | null
   isPendingInvite?: boolean
 }) {
+  const canEdit = !readonly
+
   return (
     <div className="flex flex-col gap-1 grow">
-      <div className="flex min-h-control-height items-center">
-        <Textarea
-          ref={summaryRef}
-          placeholder="Event Title"
-          value={summary ?? ""}
-          className={cn(
-            "text-base font-medium",
-            readonly && "hover:border-transparent! focus:bg-transparent!",
-          )}
-          readOnly={readonly}
-          onChange={(e) => onChangeSummary(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault()
-              onClose?.()
-            }
-          }}
-        />
-      </div>
+      {(canEdit || !!summary?.trim()) && (
+        <div className="flex min-h-control-height items-center">
+          <Textarea
+            ref={summaryRef}
+            placeholder="Event Title"
+            value={summary ?? ""}
+            className={cn(
+              "text-base font-medium",
+              readonly && "hover:border-transparent! focus:bg-transparent!",
+            )}
+            readOnly={readonly}
+            onChange={(e) => onChangeSummary(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                onClose?.()
+              }
+            }}
+          />
+        </div>
+      )}
 
       <div className="flex flex-col gap-1">
-        <LocationInput
-          value={location}
-          onChange={onLocationChange}
-          onClose={onClose}
-          readOnly={readonly}
-        />
+        {(canEdit || !!location?.trim()) && (
+          <LocationInput
+            value={location}
+            onChange={onLocationChange}
+            onClose={onClose}
+            readOnly={readonly}
+          />
+        )}
 
         <DateTimeSelect start={start} end={end} readOnly={readonly} onChange={onChangeDateTime} />
-        <AllDayCheckbox checked={allDay} onCheckedChange={onAllDayChange} readOnly={readonly} />
 
-        <RepeatSelect value={recurrence} onChange={onRecurrenceChange} readOnly={readonly} />
+        {(canEdit || allDay) && (
+          <AllDayCheckbox checked={allDay} onCheckedChange={onAllDayChange} readOnly={readonly} />
+        )}
+
+        {(canEdit || recurrence) && (
+          <RepeatSelect value={recurrence} onChange={onRecurrenceChange} readOnly={readonly} />
+        )}
 
         <ConferenceDisplay
           conference={conference}
@@ -130,7 +141,7 @@ export function EventInfo({
           onConferenceChange={onConferenceChange}
         />
 
-        {(!!attendees?.length || !readonly) && (
+        {(!!attendees?.length || canEdit) && (
           <>
             {!!attendees?.length && <Divider />}
 
@@ -145,7 +156,7 @@ export function EventInfo({
           </>
         )}
 
-        {!calendar?.read_only && (
+        {canEdit && !calendar?.read_only && (
           <ReminderSelect
             reminders={reminders ?? []}
             onSelect={onReminderAdd}
@@ -155,7 +166,9 @@ export function EventInfo({
 
         <CalendarSelect calendar={calendar} onChange={onCalendarChange} readOnly={readonly} />
 
-        <NotesInput value={description} onChange={onDescriptionChange} readOnly={readonly} />
+        {(canEdit || !!description?.trim()) && (
+          <NotesInput value={description} onChange={onDescriptionChange} readOnly={readonly} />
+        )}
 
         {onRsvp && (
           <>

--- a/src/components/event-parts/inputs/ConferenceDisplay.tsx
+++ b/src/components/event-parts/inputs/ConferenceDisplay.tsx
@@ -77,7 +77,7 @@ export function ConferenceDisplay({
 function ConferenceLink({ url, label }: { url: string; label: string }) {
   return (
     <div className="flex flex-col gap-1 px-3 py-1">
-      <Button className="w-full" onClick={() => openUrl(url)}>
+      <Button className="w-full cursor-pointer" onClick={() => openUrl(url)}>
         <VideoIcon />
         Join {label}
       </Button>

--- a/src/components/settings/calendars/CalendarsColumn.tsx
+++ b/src/components/settings/calendars/CalendarsColumn.tsx
@@ -219,8 +219,10 @@ function CalendarDropdownMenuWrapper({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem
-            disabled={isDefault}
-            onClick={() => void setDefaultCalendar(calendar.slug)}
+            disabled={isDefault || calendar.read_only === true}
+            onClick={() => {
+              if (!calendar.read_only) void setDefaultCalendar(calendar.slug)
+            }}
           >
             Set as default
           </DropdownMenuItem>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,13 +3,20 @@ import TextareaAutosizeComponent from "react-textarea-autosize"
 
 import { cn } from "@/lib/utils"
 
-export function Textarea({ className, ...props }: React.ComponentProps<typeof TextareaInner>) {
+export function Textarea({
+  className,
+  readOnly,
+  ...props
+}: React.ComponentProps<typeof TextareaInner>) {
   return (
     <div
       role="group"
-      className="group/input-group w-full border border-transparent hover:border-input min-h-control-height h-auto focus-within:bg-secondary focus-within:border-transparent! px-3 flex items-center rounded-md"
+      className={cn(
+        "group/input-group w-full border border-transparent hover:border-input min-h-control-height h-auto focus-within:bg-secondary focus-within:border-transparent! px-3 flex items-center rounded-md",
+        readOnly && "hover:border-transparent! focus-within:bg-transparent!",
+      )}
     >
-      <TextareaInner {...props} className={cn("h-full", className)} />
+      <TextareaInner {...props} readOnly={readOnly} className={cn("h-full", className)} />
     </div>
   )
 }

--- a/src/contexts/EventDraftContext.tsx
+++ b/src/contexts/EventDraftContext.tsx
@@ -10,7 +10,7 @@ import {
 } from "react"
 
 import { rpc } from "@/rpc"
-import type { EventAttendee } from "@/rpc/bindings"
+import type { Calendar, EventAttendee } from "@/rpc/bindings"
 
 import {
   type CalendarEvent,
@@ -98,16 +98,22 @@ function getClosestNextHour(): EventTime {
   return { kind: "datetime_zoned", value: z }
 }
 
+function getDefaultCalendarId(calendars: Calendar[], configuredDefault: string | null) {
+  const defaultCalendar = calendars.find(
+    (calendar) => calendar.slug === configuredDefault && !calendar.read_only,
+  )
+  const fallbackCalendar = calendars.find((calendar) => !calendar.read_only)
+
+  return defaultCalendar?.slug ?? fallbackCalendar?.slug ?? null
+}
+
 export function EventDraftProvider({ children }: { children: ReactNode }) {
   const { calendars } = useCalendars()
   const { defaultCalendar, defaultReminders } = useSettings()
   const [isDrafting, setIsDrafting] = useState(false)
   const [draftPopoverOpen, _setDraftPopoverOpen] = useState(false)
 
-  const defaultCalendarId =
-    (defaultCalendar && calendars.some((c) => c.slug === defaultCalendar)
-      ? defaultCalendar
-      : calendars[0]?.slug) ?? null
+  const defaultCalendarId = getDefaultCalendarId(calendars, defaultCalendar)
 
   const [text, _setText] = useState("")
   const [draftReminders, setDraftReminders] = useState<number[]>([])


### PR DESCRIPTION
Events that aren't editable shouldn't look editable.

**Before:**

<img width="401" height="615" alt="image" src="https://github.com/user-attachments/assets/2226edb6-b3d5-4a50-9cc0-04cfa186cf01" />


**After:**

<img width="401" height="395" alt="image" src="https://github.com/user-attachments/assets/922feb5c-2bc0-4c45-ac9b-a34e16c27bd6" />
