### PR TITLE
Bugfix: handle update to recurring date-only events

### DIFF
--- a/src/contexts/RecurrenceEditContext.tsx
+++ b/src/contexts/RecurrenceEditContext.tsx
@@ -9,8 +9,8 @@ import { useCalEvents } from "@/contexts/CalEventsContext"
 import { useSync } from "@/contexts/SyncContext"
 
 import { recurrenceToRpc, rpcToCalendarEvent, type CalendarEvent } from "@/lib/cal-events"
-import { addMinutes, instantForOrdering, wallclockTime, withWallclockTime } from "@/lib/event-time"
 import { toRpcEventTime } from "@/lib/event-time/rpc"
+import { anchorRangeToRecurringMaster } from "@/lib/recurrence-edit"
 import { updateAndSyncEvent } from "@/lib/save-event"
 
 type PendingEdit = { current: CalendarEvent; original: CalendarEvent }
@@ -110,17 +110,12 @@ export function RecurrenceEditProvider({ children }: { children: ReactNode }) {
       if (!masterRpc) return
       const master = rpcToCalendarEvent(masterRpc)
 
-      // Apply only the wall-clock time-of-day delta — the master's anchor
-      // date stays put. Date moves on the instance are silently ignored
-      // for the "all events" scope, matching Google Calendar's behavior.
-      const { hour, minute } = wallclockTime(current.start)
-      const newMasterStart = withWallclockTime(master.start, hour, minute)
-      const durationMins = Math.round(
-        (instantForOrdering(current.end).epochMilliseconds -
-          instantForOrdering(current.start).epochMilliseconds) /
-          60000,
+      // Apply the occurrence's edited range while retaining the master's anchor
+      // date. This also preserves date-only values when toggling the series all-day.
+      const { start: newMasterStart, end: newMasterEnd } = anchorRangeToRecurringMaster(
+        current,
+        master.start,
       )
-      const newMasterEnd = addMinutes(newMasterStart, durationMins)
 
       const updatedMaster: CalendarEvent = {
         ...master,

--- a/src/lib/recurrence-edit.test.ts
+++ b/src/lib/recurrence-edit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import type { EventTimeRange } from "@/lib/event-time"
+import { fromRpcEventTime, toRpcEventTime } from "@/lib/event-time/rpc"
+
+import { anchorRangeToRecurringMaster } from "./recurrence-edit"
+
+const zoned = (wallclock: string) =>
+  fromRpcEventTime({ kind: "datetime_zoned", wallclock, tzid: "Europe/London" })
+const date = (value: string) => fromRpcEventTime({ kind: "date", date: value })
+
+describe("anchorRangeToRecurringMaster", () => {
+  it("converts a timed recurring master to an all-day range", () => {
+    const current: EventTimeRange = {
+      start: date("2026-08-24"),
+      end: date("2026-08-25"),
+    }
+
+    const result = anchorRangeToRecurringMaster(current, zoned("2021-08-24T09:00:00"))
+
+    expect(toRpcEventTime(result.start)).toEqual({ kind: "date", date: "2021-08-24" })
+    expect(toRpcEventTime(result.end)).toEqual({ kind: "date", date: "2021-08-25" })
+  })
+
+  it("keeps a timed edit timed while restoring the master's anchor date", () => {
+    const current: EventTimeRange = {
+      start: zoned("2026-08-24T10:30:00"),
+      end: zoned("2026-08-24T11:30:00"),
+    }
+
+    const result = anchorRangeToRecurringMaster(current, zoned("2021-08-24T09:00:00"))
+
+    expect(toRpcEventTime(result.start)).toEqual({
+      kind: "datetime_zoned",
+      wallclock: "2021-08-24T10:30:00",
+      tzid: "Europe/London",
+    })
+    expect(toRpcEventTime(result.end)).toEqual({
+      kind: "datetime_zoned",
+      wallclock: "2021-08-24T11:30:00",
+      tzid: "Europe/London",
+    })
+  })
+})

--- a/src/lib/recurrence-edit.ts
+++ b/src/lib/recurrence-edit.ts
@@ -1,0 +1,13 @@
+import { dateInEventZone, withRangeStartDate } from "@/lib/event-time"
+import type { EventTime, EventTimeRange } from "@/lib/event-time"
+
+/**
+ * Move an edited recurring occurrence back to the master's anchor date.
+ * The occurrence supplies the range shape, including whether it is all-day.
+ */
+export function anchorRangeToRecurringMaster(
+  current: EventTimeRange,
+  masterStart: EventTime,
+): EventTimeRange {
+  return withRangeStartDate(current, dateInEventZone(masterStart))
+}


### PR DESCRIPTION
Found a bug where:

1. A recurring timed event is changed to “all-day”.
2. The change is applied to “All events”.
3. The series becomes timed from 00:00 to 00:00 the next day instead of becoming truly all-day.

This fixes the recurring edit path to preserve date-only event values while keeping the series’ original anchor date. It also adds regression tests for both all-day and timed recurring edits.
