### PR TITLE
Fix week view scroll to snap to Monday when Today is off-screen

### DIFF
--- a/src/components/main/week-view/WeekTimeGrid.tsx
+++ b/src/components/main/week-view/WeekTimeGrid.tsx
@@ -160,8 +160,13 @@ export function WeekTimeGrid({
     const viewportRight = el.scrollLeft + el.clientWidth
 
     if (columnLeft < viewportLeft - 1 || columnRight > viewportRight + 1) {
+      const activeDay = currentDays[idx]
+      const weekStartKey = formatDateKey(startOfWeek(activeDay.date, { weekStartsOn: 1 }))
+      const mondayIdx = currentDays.findIndex((d) => d.dateKey === weekStartKey)
+      const targetIdx = mondayIdx !== -1 ? mondayIdx : idx
+
       suppressScrollTracking()
-      el.scrollTo({ left: idx * currentDayWidth, behavior: "smooth" })
+      el.scrollTo({ left: targetIdx * currentDayWidth, behavior: "smooth" })
     }
   }, [activeDateKey, scrollContainerRef])
 


### PR DESCRIPTION
The off-screen activeDate scroll effect in WeekTimeGrid scrolled directly to the target date's column instead of the Monday-start of its week, unlike the initial-mount scroll which already did this correctly. This meant clicking "Today" while that day wasn't in the current view showed today as the leftmost column instead of aligning to Monday.
This fixes https://github.com/t4t5/rencal/issues/88