### PR TITLE
Add Nord theme

### DIFF
--- a/src/themes/manifest.ts
+++ b/src/themes/manifest.ts
@@ -8,6 +8,7 @@ export const themes = [
   { id: "catpuccin-latte", name: "Catpuccin Latte", appearance: "light" },
   { id: "tokyonight", name: "Tokyo Night", appearance: "dark" },
   { id: "classic", name: "Classic", appearance: "dark" },
+  { id: "nord", name: "Nord", appearance: "dark" },
 ] as const satisfies readonly { id: string; name: string; appearance: Appearance | null }[]
 
 export type ThemeId = (typeof themes)[number]["id"]

--- a/src/themes/nord.css
+++ b/src/themes/nord.css
@@ -1,0 +1,15 @@
+--background: #2e3440;
+--foreground: #eceff4;
+--muted: #d8dee9;
+--hover-tint: #88c0d0;
+--hover-mix: 12%;
+--primary: #88c0d0;
+--primary-foreground: #2e3440;
+--highlight: #81a1c1;
+--today: #5e81ac;
+--success: #a3be8c;
+--warning: #ebcb8b;
+--error: #bf616a;
+--ring: #88c0d0;
+--radius-base: 0.35rem;
+--radius-circle: calc(infinity * 1px);


### PR DESCRIPTION
## Summary
- add a built-in Nord color theme
- register Nord in the theme selector

## Verification
- `pnpm typecheck`
- `pnpm build`

<img width="2824" height="1824" alt="image" src="https://github.com/user-attachments/assets/53fcb24f-16ee-41ed-93eb-869192f7f271" />

<img width="1824" height="1224" alt="image" src="https://github.com/user-attachments/assets/6f343b87-90f3-4d5d-b2c8-4e544926cda0" />
