### PR TITLE
Add support for Omarchy Quattro

### DIFF
--- a/src-tauri/src/omarchy.rs
+++ b/src-tauri/src/omarchy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -10,56 +11,160 @@ use tokio::time::sleep;
 
 pub const OMARCHY_THEME_CHANGED: &str = "omarchy-theme-changed";
 
-#[derive(Clone, Debug, Deserialize, Serialize, Type)]
-pub struct OmarchyColors {
-    pub background: String,
-    pub foreground: String,
-    pub accent: String,
-    pub cursor: Option<String>,
-    pub selection_foreground: Option<String>,
-    pub selection_background: Option<String>,
-    pub color0: String,
-    pub color1: String,
-    pub color2: String,
-    pub color3: String,
-    pub color4: String,
-    pub color5: String,
-    pub color6: String,
-    pub color7: String,
-    pub color8: String,
-    pub color9: String,
-    pub color10: String,
-    pub color11: String,
-    pub color12: String,
-    pub color13: String,
-    pub color14: String,
-    pub color15: String,
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Type, PartialEq, Eq)]
+pub enum OmarchyMode {
+    #[serde(rename = "dark")]
+    Dark,
+    #[serde(rename = "light")]
+    Light,
 }
 
-fn omarchy_current_dir() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    Some(PathBuf::from(home).join(".config/omarchy/current"))
+#[derive(Clone, Debug, Deserialize, Serialize, Type, PartialEq, Eq)]
+pub struct OmarchyColors {
+    pub mode: OmarchyMode,
+    pub background: String,
+    pub foreground: String,
+    pub bright_foreground: String,
+    pub accent: String,
+    pub red: String,
+    pub green: String,
+    pub yellow: String,
+    pub blue: String,
+}
+
+fn candidate_dirs() -> Option<[PathBuf; 2]> {
+    let home = dirs::home_dir()?;
+    Some([
+        home.join(".local/state/omarchy/current"),
+        home.join(".config/omarchy/current"),
+    ])
 }
 
 fn colors_toml_path() -> Option<PathBuf> {
-    Some(omarchy_current_dir()?.join("theme/colors.toml"))
+    candidate_dirs()?
+        .into_iter()
+        .map(|dir| dir.join("theme/colors.toml"))
+        .find(|path| path.is_file())
+}
+
+fn string_values(table: toml::Table) -> HashMap<String, String> {
+    table
+        .into_iter()
+        .filter_map(|(key, value)| value.as_str().map(|value| (key, value.to_owned())))
+        .collect()
+}
+
+fn first_value(colors: &HashMap<String, String>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| colors.get(*key).filter(|value| !value.is_empty()).cloned())
+}
+
+fn mode_from_background(background: &str) -> OmarchyMode {
+    let Some(hex) = background.strip_prefix('#') else {
+        return OmarchyMode::Dark;
+    };
+    if hex.len() != 6 {
+        return OmarchyMode::Dark;
+    }
+
+    let components = [0, 2, 4].map(|start| u16::from_str_radix(&hex[start..start + 2], 16));
+    match components {
+        [Ok(red), Ok(green), Ok(blue)] if red + green + blue > 382 => OmarchyMode::Light,
+        _ => OmarchyMode::Dark,
+    }
+}
+
+fn resolve_mode(
+    colors: &HashMap<String, String>,
+    has_light_mode_marker: bool,
+    background: &str,
+) -> OmarchyMode {
+    for key in ["mode", "theme_type"] {
+        match colors.get(key).map(String::as_str) {
+            Some("light") => return OmarchyMode::Light,
+            Some("dark") => return OmarchyMode::Dark,
+            _ => {}
+        }
+    }
+
+    if has_light_mode_marker {
+        OmarchyMode::Light
+    } else {
+        mode_from_background(background)
+    }
+}
+
+fn resolve_colors(
+    colors: &HashMap<String, String>,
+    has_light_mode_marker: bool,
+) -> Option<OmarchyColors> {
+    let background = first_value(colors, &["background", "bg", "color0"])?;
+    let foreground = first_value(colors, &["foreground", "fg", "color7"])?;
+    let bright_foreground = first_value(
+        colors,
+        &["bright_foreground", "bright_fg", "cursor", "color15"],
+    )
+    .unwrap_or_else(|| foreground.clone());
+    let accent =
+        first_value(colors, &["accent", "color4", "blue"]).unwrap_or_else(|| foreground.clone());
+    let red = first_value(colors, &["red", "color1"]).unwrap_or_else(|| accent.clone());
+    let green = first_value(colors, &["green", "color2"]).unwrap_or_else(|| accent.clone());
+    let yellow = first_value(colors, &["yellow", "color3"]).unwrap_or_else(|| accent.clone());
+    let blue = first_value(colors, &["blue", "color4"]).unwrap_or_else(|| accent.clone());
+    let mode = resolve_mode(colors, has_light_mode_marker, &background);
+
+    Some(OmarchyColors {
+        mode,
+        background,
+        foreground,
+        bright_foreground,
+        accent,
+        red,
+        green,
+        yellow,
+        blue,
+    })
 }
 
 pub fn read_colors() -> Option<OmarchyColors> {
     let path = colors_toml_path()?;
-    let contents = std::fs::read_to_string(path).ok()?;
-    toml::from_str(&contents).ok()
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            log::warn!("Failed to read Omarchy colors from {path:?}: {error}");
+            return None;
+        }
+    };
+    let table = match toml::from_str::<toml::Table>(&contents) {
+        Ok(table) => table,
+        Err(error) => {
+            log::warn!("Failed to parse Omarchy colors from {path:?}: {error}");
+            return None;
+        }
+    };
+    let has_light_mode_marker = path
+        .parent()
+        .is_some_and(|theme_dir| theme_dir.join("light.mode").is_file());
+    let resolved = resolve_colors(&string_values(table), has_light_mode_marker);
+    if resolved.is_none() {
+        log::warn!("Omarchy colors at {path:?} have no resolvable background or foreground");
+    }
+    resolved
 }
 
-/// Watches `~/.config/omarchy/current/` recursively and emits `OMARCHY_THEME_CHANGED`
-/// whenever `colors.toml` is updated — including the atomic `rm -rf current/theme;
-/// mv next-theme current/theme` swap performed by `omarchy-theme-set`.
+/// Watches every existing Omarchy current-theme directory recursively and emits
+/// `OMARCHY_THEME_CHANGED` whenever its contents change. This includes both the
+/// v3 and quattro paths and their atomic next-theme swaps.
 pub async fn run_watcher(app: AppHandle) {
-    let Some(watch_dir) = omarchy_current_dir() else {
+    let Some(candidate_dirs) = candidate_dirs() else {
         return;
     };
-    if !watch_dir.exists() {
-        log::info!("Omarchy not detected at {watch_dir:?}; theme watcher disabled");
+    let watch_dirs: Vec<_> = candidate_dirs
+        .into_iter()
+        .filter(|dir| dir.exists())
+        .collect();
+    if watch_dirs.is_empty() {
+        log::info!("Omarchy not detected; theme watcher disabled");
         return;
     }
 
@@ -75,15 +180,21 @@ pub async fn run_watcher(app: AppHandle) {
             let _ = tx.send(());
         }
     }) {
-        Ok(w) => w,
-        Err(e) => {
-            log::warn!("Failed to init Omarchy theme watcher: {e}");
+        Ok(watcher) => watcher,
+        Err(error) => {
+            log::warn!("Failed to init Omarchy theme watcher: {error}");
             return;
         }
     };
 
-    if let Err(e) = watcher.watch(&watch_dir, RecursiveMode::Recursive) {
-        log::warn!("Failed to watch {watch_dir:?}: {e}");
+    let mut watched_any = false;
+    for watch_dir in watch_dirs {
+        match watcher.watch(&watch_dir, RecursiveMode::Recursive) {
+            Ok(()) => watched_any = true,
+            Err(error) => log::warn!("Failed to watch {watch_dir:?}: {error}"),
+        }
+    }
+    if !watched_any {
         return;
     }
 
@@ -98,4 +209,220 @@ pub async fn run_watcher(app: AppHandle) {
     }
 
     drop(watcher);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_fixture(contents: &str) -> HashMap<String, String> {
+        string_values(toml::from_str::<toml::Table>(contents).unwrap())
+    }
+
+    #[test]
+    fn resolves_quattro_canonical_colors() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                mode = "dark"
+                accent = "#7aa2f7"
+                background = "#1a1b26"
+                foreground = "#a9b1d6"
+                bright_foreground = "#c0caf5"
+                red = "#f7768e"
+                green = "#9ece6a"
+                yellow = "#e0af68"
+                blue = "#7aa2f7"
+                color1 = "#ignored"
+                gradient_angle = 45
+                "##,
+            ),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(colors.mode, OmarchyMode::Dark);
+        assert_eq!(colors.background, "#1a1b26");
+        assert_eq!(colors.foreground, "#a9b1d6");
+        assert_eq!(colors.bright_foreground, "#c0caf5");
+        assert_eq!(colors.accent, "#7aa2f7");
+        assert_eq!(colors.red, "#f7768e");
+    }
+
+    #[test]
+    fn honors_quattro_light_mode() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                mode = "light"
+                background = "#FFFCF0"
+                foreground = "#100F0F"
+                accent = "#205EA6"
+                "##,
+            ),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(colors.mode, OmarchyMode::Light);
+    }
+
+    #[test]
+    fn resolves_v3_full_palette() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                background = "#1a1b26"
+                foreground = "#a9b1d6"
+                cursor = "#c0caf5"
+                color0 = "#15161e"
+                color1 = "#f7768e"
+                color2 = "#9ece6a"
+                color3 = "#e0af68"
+                color4 = "#7aa2f7"
+                color5 = "#bb9af7"
+                color6 = "#7dcfff"
+                color7 = "#a9b1d6"
+                color8 = "#414868"
+                color9 = "#f7768e"
+                color10 = "#9ece6a"
+                color11 = "#e0af68"
+                color12 = "#7aa2f7"
+                color13 = "#bb9af7"
+                color14 = "#7dcfff"
+                color15 = "#acb0d0"
+                "##,
+            ),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(colors.mode, OmarchyMode::Dark);
+        assert_eq!(colors.bright_foreground, "#c0caf5");
+        assert_eq!(colors.red, "#f7768e");
+        assert_eq!(colors.green, "#9ece6a");
+        assert_eq!(colors.yellow, "#e0af68");
+        assert_eq!(colors.blue, "#7aa2f7");
+    }
+
+    #[test]
+    fn resolves_alacritty_hybrid_palette() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                accent = "#112233"
+                selection = "#223344"
+                background = "#101010"
+                foreground = "#eeeeee"
+                color0 = "#000000"
+                color1 = "#aa0000"
+                color2 = "#00aa00"
+                color3 = "#aaaa00"
+                color4 = "#0000aa"
+                color7 = "#aaaaaa"
+                color15 = "#ffffff"
+                "##,
+            ),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(colors.accent, "#112233");
+        assert_eq!(colors.bright_foreground, "#ffffff");
+        assert_eq!(colors.red, "#aa0000");
+        assert_eq!(colors.blue, "#0000aa");
+    }
+
+    #[test]
+    fn resolves_ansi_only_palette() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                color0 = "#101010"
+                color1 = "#aa0000"
+                color2 = "#00aa00"
+                color3 = "#aaaa00"
+                color4 = "#0000aa"
+                color5 = "#aa00aa"
+                color6 = "#00aaaa"
+                color7 = "#eeeeee"
+                color8 = "#555555"
+                color9 = "#ff0000"
+                color10 = "#00ff00"
+                color11 = "#ffff00"
+                color12 = "#0000ff"
+                color13 = "#ff00ff"
+                color14 = "#00ffff"
+                color15 = "#ffffff"
+                "##,
+            ),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(colors.background, "#101010");
+        assert_eq!(colors.foreground, "#eeeeee");
+        assert_eq!(colors.bright_foreground, "#ffffff");
+        assert_eq!(colors.accent, "#0000aa");
+    }
+
+    #[test]
+    fn rejects_palettes_without_background_or_foreground() {
+        assert!(resolve_colors(&HashMap::new(), false).is_none());
+        assert!(
+            resolve_colors(
+                &parse_fixture(
+                    r##"
+                    background = "#101010"
+                    "##
+                ),
+                false,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn light_mode_marker_precedes_luminance() {
+        let colors = resolve_colors(
+            &parse_fixture(
+                r##"
+                background = "#101010"
+                foreground = "#eeeeee"
+                "##,
+            ),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(colors.mode, OmarchyMode::Light);
+    }
+
+    #[test]
+    #[ignore = "requires the local Omarchy quattro checkout"]
+    fn resolves_all_quattro_themes() {
+        let themes_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../omarchy/themes");
+        let mut resolved_count = 0;
+
+        for entry in std::fs::read_dir(&themes_dir).unwrap() {
+            let colors_path = entry.unwrap().path().join("colors.toml");
+            if !colors_path.is_file() {
+                continue;
+            }
+
+            let contents = std::fs::read_to_string(&colors_path).unwrap();
+            let colors = parse_fixture(&contents);
+            assert!(
+                resolve_colors(&colors, colors_path.with_file_name("light.mode").is_file())
+                    .is_some(),
+                "failed to resolve {colors_path:?}"
+            );
+            resolved_count += 1;
+        }
+
+        assert!(
+            resolved_count > 0,
+            "no quattro themes found in {themes_dir:?}"
+        );
+    }
 }

--- a/src/hooks/useOmarchyTheme.ts
+++ b/src/hooks/useOmarchyTheme.ts
@@ -5,8 +5,6 @@ import { useEffect } from "react"
 import { rpc } from "@/rpc"
 import type { OmarchyColors } from "@/rpc/bindings"
 
-import { appearanceFromHex } from "@/themes/appearance"
-
 const OMARCHY_THEME_CHANGED = "omarchy-theme-changed"
 const CACHE_KEY = "omarchyColors"
 const STYLE_ELEMENT_ID = "omarchy-theme-vars"
@@ -33,33 +31,32 @@ function luminance(hex: string): number {
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255
 }
 
-// Some Omarchy themes set `cursor` to a brighter variant of the body text
+// Some Omarchy themes set `bright_foreground` to a brighter variant of the body text
 // (tokyo-night, catppuccin), others to an accent tint (catppuccin-latte's
 // rosewater, rose-pine's pale gray) that reads poorly as primary text.
-// Pick whichever of cursor/foreground contrasts the background more.
+// Pick whichever foreground variant contrasts the background more.
 function pickForeground(c: OmarchyColors): string {
-  if (!c.cursor) return c.foreground
   const bg = luminance(c.background)
   const fgContrast = Math.abs(luminance(c.foreground) - bg)
-  const cursorContrast = Math.abs(luminance(c.cursor) - bg)
-  return cursorContrast > fgContrast ? c.cursor : c.foreground
+  const brightFgContrast = Math.abs(luminance(c.bright_foreground) - bg)
+  return brightFgContrast > fgContrast ? c.bright_foreground : c.foreground
 }
 
 function varsFromColors(c: OmarchyColors): Record<(typeof CSS_VARS)[number], string> {
   const fg = pickForeground(c)
-  const popoverTint = appearanceFromHex(c.background) === "light" ? "white" : "black"
+  const popoverTint = c.mode === "light" ? "white" : "black"
   return {
     "--background": c.background,
     "--foreground": fg,
     "--primary": c.accent,
-    "--today": c.color4,
-    "--highlight": c.color1,
+    "--today": c.blue,
+    "--highlight": c.red,
     "--hover-tint": fg,
     "--muted": `color-mix(in srgb, ${fg} 55%, transparent)`,
     "--popover-tint": popoverTint,
-    "--success": c.color2,
-    "--warning": c.color3,
-    "--error": c.color1,
+    "--success": c.green,
+    "--warning": c.yellow,
+    "--error": c.red,
   }
 }
 
@@ -88,9 +85,9 @@ function applyOmarchyColors(c: OmarchyColors) {
     localStorage.setItem(CACHE_KEY, JSON.stringify(c))
   } catch {}
   // Sync OS window chrome if omarchy is the active theme. useTheme can't
-  // do this itself because the appearance is derived from these colors.
+  // do this itself because the appearance comes from Omarchy's palette.
   if (document.body.dataset.theme === "omarchy") {
-    void getCurrentWindow().setTheme(appearanceFromHex(c.background))
+    void getCurrentWindow().setTheme(c.mode)
     // Keep index.html's flash-prevention cache in step with the live OS theme.
     try {
       localStorage.setItem("themeBackground", c.background)

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -34,7 +34,9 @@ export type ExternalTheme = { id: string;
  */
 name: string; css: string }
 
-export type OmarchyColors = { background: string; foreground: string; accent: string; cursor: string | null; selection_foreground: string | null; selection_background: string | null; color0: string; color1: string; color2: string; color3: string; color4: string; color5: string; color6: string; color7: string; color8: string; color9: string; color10: string; color11: string; color12: string; color13: string; color14: string; color15: string }
+export type OmarchyColors = { mode: OmarchyMode; background: string; foreground: string; bright_foreground: string; accent: string; red: string; green: string; yellow: string; blue: string }
+
+export type OmarchyMode = "dark" | "light"
 
 export type ProviderConnectInfo = { step: ProviderConnectStepKind; fields: ProviderField[]; instructions: string | null }
 

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -114,11 +114,11 @@ These are unset by default. Setting them from a theme opts into theme-specific t
 
 ## Omarchy auto-sync
 
-The `omarchy` theme is special: it doesn't ship a static palette. renCal reads `~/.config/omarchy/current/theme/colors.toml` at runtime and writes the colors into a managed `<style>` element as a `[data-theme="omarchy"] { ... }` rule. A Rust file-watcher (see `src-tauri/src/omarchy.rs`) re-emits on every OS theme change, so running `omarchy-theme-next` repaints renCal live without a restart.
+The `omarchy` theme is special: it doesn't ship a static palette. renCal reads `~/.local/state/omarchy/current/theme/colors.toml` on Omarchy quattro or `~/.config/omarchy/current/theme/colors.toml` on v3, then writes the colors into a managed `<style>` element as a `[data-theme="omarchy"] { ... }` rule. The Rust integration in `src-tauri/src/omarchy.rs` normalizes v3 ANSI, v4 semantic, and hybrid palettes into one shape. Its file-watcher re-emits on every OS theme change, so changing the Omarchy theme repaints renCal live without a restart.
 
 The fetch + listen runs regardless of the active theme so the omarchy preview tile in settings always reflects the current OS theme — the `[data-theme="omarchy"]` selector keeps the rule from leaking to other themes.
 
-If Omarchy isn't installed (or `colors.toml` is missing), no rule is written and the theme falls through to the `:root` defaults in `global.css`. The color mapping from `colors.toml` keys to CSS variables lives in `src/hooks/useOmarchyTheme.ts` — tweak it there.
+If Omarchy isn't installed (or `colors.toml` is missing), no rule is written and the theme falls through to the `:root` defaults in `global.css`. Palette fallback resolution lives in `src-tauri/src/omarchy.rs`; the normalized semantic-color to CSS-variable mapping lives in `src/hooks/useOmarchyTheme.ts`.
 
 ## Escape hatch: custom CSS rules
 

--- a/src/themes/omarchy.css
+++ b/src/themes/omarchy.css
@@ -1,5 +1,6 @@
 /* The Omarchy theme's primitives are injected at runtime from
-   ~/.config/omarchy/current/theme/colors.toml via src/hooks/useOmarchyTheme.ts,
+   ~/.local/state/omarchy/current/theme/colors.toml (quattro) or
+   ~/.config/omarchy/current/theme/colors.toml (v3) via src/hooks/useOmarchyTheme.ts,
    which writes a [data-theme="omarchy"] rule into a managed <style> element
    appended to <head>. The values below act as a fallback for users who
    aren't on Omarchy (so the theme still has a coherent look in the settings


### PR DESCRIPTION
Omarchy Quattro changes [how themes are defined](https://github.com/basecamp/omarchy/pull/4541).

renCal should support both Quattro and older versions of Omarchy.

It now checks both the old `.config/omarchy/current` and the new `.local/state/omarchy/current` to see what the active theme is.

https://github.com/user-attachments/assets/eae2f0c0-437c-423b-9821-3b5c241ff079


