### PR TITLE
Add collapsible sidebar via ctrl+b shortcut (#103)

### DIFF
--- a/src/components/main/month-view/Grid.tsx
+++ b/src/components/main/month-view/Grid.tsx
@@ -57,6 +57,7 @@ export function MonthGrid({
 
   // Each day cell is a square: row height tracks the column width
   const [rowHeight, setRowHeight] = useState(DEFAULT_ROW_HEIGHT)
+  const prevRowHeightRef = useRef(rowHeight)
 
   // Hide the grid until the initial anchor scroll lands, so the user never sees the
   // pre-scroll frame (top of the grid) flash before it jumps to the active month.
@@ -82,6 +83,31 @@ export function MonthGrid({
     estimateSize,
     overscan: 3,
   })
+
+  // When the row height changes (e.g. sidebar toggle or window resize), rescale
+  // scrollTop so the viewport stays on the same week instead of jumping. Placed
+  // after the virtualizer so it can call measure() on it.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    const prevHeight = prevRowHeightRef.current
+    prevRowHeightRef.current = rowHeight
+
+    if (!el || prevHeight === rowHeight || prevHeight === 0 || !hasInitiallyScrolled) return
+
+    const ratio = rowHeight / prevHeight
+    const newScrollTop = Math.round(el.scrollTop * ratio)
+
+    debugMonthScroll("rescale scrollTop after row height change", {
+      prevHeight,
+      rowHeight,
+      ratio,
+      prevScrollTop: el.scrollTop,
+      newScrollTop,
+    })
+
+    el.scrollTop = newScrollTop
+    virtualizer.measure()
+  }, [rowHeight, virtualizer, scrollRef, hasInitiallyScrolled])
 
   // anchorWeekIndex shifts when weeks are prepended/appended; keep it in a ref so the
   // one-time initial scroll can read the latest value without re-running on every shift.

--- a/src/components/shortcuts/GlobalShortcuts.tsx
+++ b/src/components/shortcuts/GlobalShortcuts.tsx
@@ -39,8 +39,10 @@ type ShortcutHandler = (e?: KeyboardEvent) => void
 // Isolated so context updates in the shortcut handlers don't re-render <App />.
 export function GlobalShortcuts({
   onChangeCalendarView,
+  onToggleSidebar,
 }: {
   onChangeCalendarView: (view: CalendarView) => void
+  onToggleSidebar: () => void
 }) {
   const [overlayOpen, setOverlayOpen] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -54,6 +56,7 @@ export function GlobalShortcuts({
 
   const handlers = useShortcutHandlers({
     onChangeCalendarView,
+    onToggleSidebar,
     openShortcutsOverlay: () => setOverlayOpen(true),
     toggleCommandPalette: () => {
       setPalettePage("root")
@@ -137,6 +140,7 @@ export function GlobalShortcuts({
 
 function useShortcutHandlers({
   onChangeCalendarView,
+  onToggleSidebar,
   openShortcutsOverlay,
   toggleCommandPalette,
   openGoToDate,
@@ -146,6 +150,7 @@ function useShortcutHandlers({
   setActiveGroup,
 }: {
   onChangeCalendarView: (view: CalendarView) => void
+  onToggleSidebar: () => void
   openShortcutsOverlay: () => void
   toggleCommandPalette: () => void
   openGoToDate: () => void
@@ -266,6 +271,10 @@ function useShortcutHandlers({
     week: () => onChangeCalendarView("week"),
     board: () => onChangeCalendarView("board"),
     "switch-group": switchGroup,
+    "toggle-sidebar": (e) => {
+      e?.preventDefault()
+      onToggleSidebar()
+    },
     search: handleSearch,
     "compose-event": handleComposeEvent,
     "add-event": handleAddEventToActiveDay,

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,12 +1,17 @@
+import { cn } from "@/lib/utils"
+
 import { Agenda } from "./agenda/Agenda"
 import { SidebarHeader } from "./header/SidebarHeader"
 import { Minical } from "./minical/Minical"
 
 export function Sidebar({ collapsed = false }: { collapsed?: boolean }) {
-  if (collapsed) return null
-
   return (
-    <div className="w-full md:w-[300px] flex flex-col shrink-0 md:border-r border-r-divider overflow-hidden">
+    <div
+      className={cn(
+        "w-full md:w-[300px] flex flex-col shrink-0 md:border-r border-r-divider overflow-hidden",
+        collapsed && "md:hidden",
+      )}
+    >
       <SidebarHeader />
       <Minical />
       <Agenda />

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -2,7 +2,9 @@ import { Agenda } from "./agenda/Agenda"
 import { SidebarHeader } from "./header/SidebarHeader"
 import { Minical } from "./minical/Minical"
 
-export function Sidebar() {
+export function Sidebar({ collapsed = false }: { collapsed?: boolean }) {
+  if (collapsed) return null
+
   return (
     <div className="w-full md:w-[300px] flex flex-col shrink-0 md:border-r border-r-divider overflow-hidden">
       <SidebarHeader />

--- a/src/contexts/SidebarCollapseContext.tsx
+++ b/src/contexts/SidebarCollapseContext.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, createContext, useCallback, useContext, useMemo } from "react"
+import { z } from "zod"
+
+import { useLocalStorage } from "@/hooks/useLocalStorage"
+
+const sidebarCollapsedSchema = z.boolean()
+
+const SIDEBAR_COLLAPSED_KEY = "rencal-sidebar-collapsed"
+
+interface SidebarCollapseContextType {
+  collapsed: boolean
+  setCollapsed: (collapsed: boolean) => void
+  toggleCollapsed: () => void
+}
+
+const SidebarCollapseContext = createContext({} as SidebarCollapseContextType)
+
+export function useSidebarCollapse() {
+  return useContext(SidebarCollapseContext)
+}
+
+export function SidebarCollapseProvider({ children }: { children: ReactNode }) {
+  const [collapsed, setCollapsed] = useLocalStorage(
+    SIDEBAR_COLLAPSED_KEY,
+    sidebarCollapsedSchema,
+    false,
+  )
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed(!collapsed)
+  }, [collapsed, setCollapsed])
+
+  const value = useMemo(
+    () => ({ collapsed, setCollapsed, toggleCollapsed }),
+    [collapsed, setCollapsed, toggleCollapsed],
+  )
+
+  return <SidebarCollapseContext.Provider value={value}>{children}</SidebarCollapseContext.Provider>
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -117,6 +117,12 @@ export const SHORTCUTS = [
     bindings: [{ keys: "g", type: "char" }],
   },
   {
+    id: "toggle-sidebar",
+    group: "View",
+    label: "Toggle sidebar",
+    bindings: [{ keys: "ctrl+b", type: "hotkey" }],
+  },
+  {
     id: "search",
     group: "General",
     label: "Search",

--- a/src/windows/AppWindow.tsx
+++ b/src/windows/AppWindow.tsx
@@ -15,6 +15,7 @@ import { CalEventsProvider } from "@/contexts/CalEventsContext"
 import { CreateEventGateProvider } from "@/contexts/CreateEventGateContext"
 import { EventDraftProvider } from "@/contexts/EventDraftContext"
 import { RecurrenceEditProvider } from "@/contexts/RecurrenceEditContext"
+import { SidebarCollapseProvider, useSidebarCollapse } from "@/contexts/SidebarCollapseContext"
 import { SyncProvider } from "@/contexts/SyncContext"
 
 import { useBreakpoint } from "@/hooks/useBreakpoint"
@@ -29,7 +30,9 @@ export function AppWindow({ preload }: { preload: Preload }) {
           <EventDraftProvider>
             <CreateEventGateProvider>
               <AgendaFocusProvider>
-                <App />
+                <SidebarCollapseProvider>
+                  <App />
+                </SidebarCollapseProvider>
               </AgendaFocusProvider>
             </CreateEventGateProvider>
           </EventDraftProvider>
@@ -44,15 +47,17 @@ export function AppWindow({ preload }: { preload: Preload }) {
 
 function App() {
   const { calendarView, setCalendarView } = useCalendarView()
+  const { collapsed, toggleCollapsed } = useSidebarCollapse()
 
   const isMd = useBreakpoint("md")
+  const sidebarCollapsed = collapsed && isMd
 
   return (
     <main className="flex h-screen overflow-clip">
-      <GlobalShortcuts onChangeCalendarView={setCalendarView} />
+      <GlobalShortcuts onChangeCalendarView={setCalendarView} onToggleSidebar={toggleCollapsed} />
       <DragRegion className="absolute h-4! w-full" />
 
-      <Sidebar />
+      <Sidebar collapsed={sidebarCollapsed} />
 
       {isMd && <Main calendarView={calendarView} onChangeCalendarView={setCalendarView} />}
 

--- a/src/windows/AppWindow.tsx
+++ b/src/windows/AppWindow.tsx
@@ -50,14 +50,13 @@ function App() {
   const { collapsed, toggleCollapsed } = useSidebarCollapse()
 
   const isMd = useBreakpoint("md")
-  const sidebarCollapsed = collapsed && isMd
 
   return (
     <main className="flex h-screen overflow-clip">
       <GlobalShortcuts onChangeCalendarView={setCalendarView} onToggleSidebar={toggleCollapsed} />
       <DragRegion className="absolute h-4! w-full" />
 
-      <Sidebar collapsed={sidebarCollapsed} />
+      <Sidebar collapsed={collapsed} />
 
       {isMd && <Main calendarView={calendarView} onChangeCalendarView={setCalendarView} />}
 


### PR DESCRIPTION
PR for #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to collapse and expand the sidebar.
  - Added a View shortcut using **Ctrl+B** to toggle the sidebar.
  - Sidebar state is remembered between sessions.

- **Bug Fixes**
  - Improved calendar scrolling when resizing or toggling the sidebar, keeping the same week visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->