### PR TITLE
Fix `rencal://` links on Linux

### DIFF
--- a/src-tauri/linux/rencal.desktop
+++ b/src-tauri/linux/rencal.desktop
@@ -1,0 +1,17 @@
+# Copy of tauri-bundler's default main.desktop template with one change: %u
+# on the Exec line. Without a field code, GLib-based launchers (GNOME,
+# gio open, portals) drop the URL when dispatching rencal:// deep links.
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %u
+StartupWMClass={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/src-tauri/src/deep_links.rs
+++ b/src-tauri/src/deep_links.rs
@@ -89,10 +89,10 @@ pub fn unquote_registered_desktop_exec(app: &tauri::App) {
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return;
     };
-    if let Some(fixed) = unquote_desktop_exec(&contents, &exe.to_string_lossy()) {
-        if let Err(error) = std::fs::write(&path, fixed) {
-            log::warn!("failed to unquote Exec in {}: {error}", path.display());
-        }
+    if let Some(fixed) = unquote_desktop_exec(&contents, &exe.to_string_lossy())
+        && let Err(error) = std::fs::write(&path, fixed)
+    {
+        log::warn!("failed to unquote Exec in {}: {error}", path.display());
     }
 }
 

--- a/src-tauri/src/deep_links.rs
+++ b/src-tauri/src/deep_links.rs
@@ -69,6 +69,48 @@ pub fn take_pending_event_links() -> Vec<EventDeepLink> {
     EVENT_LINK_INBOX.lock().unwrap().drain(..).collect()
 }
 
+/// See: https://github.com/tauri-apps/plugins-workspace/pull/3374
+#[cfg(all(debug_assertions, target_os = "linux"))]
+pub fn unquote_registered_desktop_exec(app: &tauri::App) {
+    use tauri::Manager;
+
+    let Ok(exe) = tauri::utils::platform::current_exe() else {
+        return;
+    };
+    let Some(file_name) = exe.file_name() else {
+        return;
+    };
+    let Ok(data_dir) = app.path().data_dir() else {
+        return;
+    };
+    let path = data_dir
+        .join("applications")
+        .join(format!("{}-handler.desktop", file_name.to_string_lossy()));
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    if let Some(fixed) = unquote_desktop_exec(&contents, &exe.to_string_lossy()) {
+        if let Err(error) = std::fs::write(&path, fixed) {
+            log::warn!("failed to unquote Exec in {}: {error}", path.display());
+        }
+    }
+}
+
+/// Returns the contents with `Exec="<exe>"` rewritten to `Exec=<exe>`, or
+/// None when nothing needs (or is safe) to change. Paths containing spaces or
+/// quotes keep the plugin's quoting, since dropping it would break the entry
+/// for spec-compliant launchers instead.
+#[cfg(all(debug_assertions, target_os = "linux"))]
+fn unquote_desktop_exec(contents: &str, exe: &str) -> Option<String> {
+    if exe.contains(' ') || exe.contains('"') {
+        return None;
+    }
+    let quoted = format!("Exec=\"{exe}\"");
+    contents
+        .contains(&quoted)
+        .then(|| contents.replace(&quoted, &format!("Exec={exe}")))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -127,6 +169,29 @@ mod tests {
         ] {
             assert!(parse_event_deep_link(url).is_err(), "accepted {url}");
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unquotes_exec_line_written_by_deep_link_plugin() {
+        let contents = "[Desktop Entry]\nType=Application\nExec=\"/home/me/rencal\" %u\nMimeType=x-scheme-handler/rencal\n";
+        assert_eq!(
+            unquote_desktop_exec(contents, "/home/me/rencal").unwrap(),
+            "[Desktop Entry]\nType=Application\nExec=/home/me/rencal %u\nMimeType=x-scheme-handler/rencal\n"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn leaves_unquoted_or_unsafe_exec_lines_alone() {
+        assert!(unquote_desktop_exec("Exec=/home/me/rencal %u\n", "/home/me/rencal").is_none());
+        assert!(
+            unquote_desktop_exec(
+                "Exec=\"/path with space/rencal\" %u\n",
+                "/path with space/rencal"
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,7 +173,10 @@ pub async fn run() {
             setup_bundled_providers(app);
 
             #[cfg(all(debug_assertions, target_os = "linux"))]
-            app.deep_link().register_all()?;
+            {
+                app.deep_link().register_all()?;
+                deep_links::unquote_registered_desktop_exec(app);
+            }
 
             if let Some(urls) = app.deep_link().get_current()? {
                 let urls: Vec<String> = urls.into_iter().map(|url| url.to_string()).collect();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,6 +44,7 @@
     "linux": {
       "deb": {
         "depends": ["libnotify-bin"],
+        "desktopTemplate": "linux/rencal.desktop",
         "files": {
           "/usr/bin/rencal-notifierd": "target/release/rencal-notifierd",
           "/usr/lib/systemd/user/rencal-notifierd.service": "notifierd/rencal-notifierd.service",
@@ -52,6 +53,7 @@
       },
       "rpm": {
         "depends": ["libnotify"],
+        "desktopTemplate": "linux/rencal.desktop",
         "files": {
           "/usr/bin/rencal-notifierd": "target/release/rencal-notifierd",
           "/usr/lib/systemd/user/rencal-notifierd.service": "notifierd/rencal-notifierd.service",


### PR DESCRIPTION
[tauri-plugin-deep-link](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/deep-link) registers dev builds with a quoted Exec path (`Exec="/path/to/rencal" %u`) in the .desktop file it writes.

xdg-open's generic-DE parser (Hyprland etc.) can't handle the quotes, so it silently falls back to opening `rencal://` URLs in the browser (which is just a blank page).

### Fixes:

- Unquote the Exec line after `register_all()` (dev builds only). This issue is documented in https://github.com/tauri-apps/plugins-workspace/pull/3374 but is unmerged.
- Add `%u` to the bundled .desktop file's Exec line so launchers pass the URL along (without it, deep links silently break on e.g. GNOME)