### PR TITLE
Add first_day_of_week setting to RencalConfig

### DIFF
--- a/docs/scroll-behaviour.md
+++ b/docs/scroll-behaviour.md
@@ -61,8 +61,9 @@ never controls it.
 
 ### Active date while scrolling
 
-- On open, the strip is positioned so the Monday of the active date's week is at the far
-  left, with the active day highlighted within that week.
+- On open, the strip is positioned so the first day of the active date's week (per the
+  first-day-of-week setting) is at the far left, with the active day highlighted within
+  that week.
 - As the user scrolls, the active date follows but the viewport is never programmatically
   moved. The active date does not change mid-scroll; once scrolling settles, it becomes
   the leftmost fully-visible day column.

--- a/src-tauri/rencal-config/src/lib.rs
+++ b/src-tauri/rencal-config/src/lib.rs
@@ -21,6 +21,14 @@ fn default_auto_sync_enabled() -> bool {
     true
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum FirstDayOfWeek {
+    #[default]
+    Monday,
+    Sunday,
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RencalConfig {
     #[serde(default = "default_theme")]
@@ -31,6 +39,9 @@ pub struct RencalConfig {
 
     #[serde(default = "default_auto_sync_enabled")]
     pub auto_sync_enabled: bool,
+
+    #[serde(default)]
+    pub first_day_of_week: FirstDayOfWeek,
 
     /// Must come AFTER top-level configs since it adds [groups] table header:
     #[serde(default)]
@@ -43,6 +54,7 @@ impl Default for RencalConfig {
             theme: default_theme(),
             notifications_enabled: default_notifications_enabled(),
             auto_sync_enabled: default_auto_sync_enabled(),
+            first_day_of_week: FirstDayOfWeek::default(),
             groups: BTreeMap::new(),
         }
     }
@@ -117,5 +129,20 @@ mod tests {
     fn missing_groups_falls_back_to_empty() {
         let config: RencalConfig = toml::from_str("theme = \"ren\"").expect("parse");
         assert!(config.groups.is_empty());
+    }
+
+    #[test]
+    fn first_day_of_week_defaults_to_monday_and_round_trips() {
+        let config: RencalConfig = toml::from_str("theme = \"ren\"").expect("parse");
+        assert_eq!(config.first_day_of_week, FirstDayOfWeek::Monday);
+
+        let config = RencalConfig {
+            first_day_of_week: FirstDayOfWeek::Sunday,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string_pretty(&config).expect("serialize");
+        assert!(toml_str.contains("first_day_of_week = \"sunday\""));
+        let reparsed: RencalConfig = toml::from_str(&toml_str).expect("re-parse");
+        assert_eq!(reparsed.first_day_of_week, FirstDayOfWeek::Sunday);
     }
 }

--- a/src-tauri/src/routes/config.rs
+++ b/src-tauri/src/routes/config.rs
@@ -1,8 +1,38 @@
 use std::collections::BTreeMap;
 
 use rencal_config::RencalConfig;
+use serde::{Deserialize, Serialize};
+use specta::Type;
 
 use crate::routes::TauResult;
+
+/// RPC mirror of `rencal_config::FirstDayOfWeek` (the config crate stays free
+/// of specta/taurpc so the notifier daemon can depend on it).
+#[derive(Clone, Copy, Serialize, Deserialize, Type)]
+pub enum FirstDayOfWeek {
+    #[serde(rename = "monday")]
+    Monday,
+    #[serde(rename = "sunday")]
+    Sunday,
+}
+
+impl From<rencal_config::FirstDayOfWeek> for FirstDayOfWeek {
+    fn from(value: rencal_config::FirstDayOfWeek) -> Self {
+        match value {
+            rencal_config::FirstDayOfWeek::Monday => Self::Monday,
+            rencal_config::FirstDayOfWeek::Sunday => Self::Sunday,
+        }
+    }
+}
+
+impl From<FirstDayOfWeek> for rencal_config::FirstDayOfWeek {
+    fn from(value: FirstDayOfWeek) -> Self {
+        match value {
+            FirstDayOfWeek::Monday => Self::Monday,
+            FirstDayOfWeek::Sunday => Self::Sunday,
+        }
+    }
+}
 
 // `get_theme` returns `Some(theme)` if the config file exists, `None` if it
 // has never been written. The frontend uses the `None` case to migrate a
@@ -15,6 +45,8 @@ pub trait ConfigApi {
     async fn set_notifications_enabled(enabled: bool) -> TauResult<()>;
     async fn get_auto_sync_enabled() -> TauResult<bool>;
     async fn set_auto_sync_enabled(enabled: bool) -> TauResult<()>;
+    async fn get_first_day_of_week() -> TauResult<FirstDayOfWeek>;
+    async fn set_first_day_of_week(day: FirstDayOfWeek) -> TauResult<()>;
     async fn get_groups() -> TauResult<BTreeMap<String, Vec<String>>>;
     async fn set_groups(groups: BTreeMap<String, Vec<String>>) -> TauResult<()>;
 }
@@ -54,6 +86,16 @@ impl ConfigApi for ConfigApiImpl {
     async fn set_auto_sync_enabled(self, enabled: bool) -> TauResult<()> {
         let mut config = RencalConfig::load();
         config.auto_sync_enabled = enabled;
+        config.save()
+    }
+
+    async fn get_first_day_of_week(self) -> TauResult<FirstDayOfWeek> {
+        Ok(RencalConfig::load().first_day_of_week.into())
+    }
+
+    async fn set_first_day_of_week(self, day: FirstDayOfWeek) -> TauResult<()> {
+        let mut config = RencalConfig::load();
+        config.first_day_of_week = day.into();
         config.save()
     }
 

--- a/src/components/main/board-view/BoardView.tsx
+++ b/src/components/main/board-view/BoardView.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { BoardColumn } from "@/components/main/board-view/BoardColumn"
 
 import { useCalEvents } from "@/contexts/CalEventsContext"
+import { useSettings } from "@/contexts/SettingsContext"
 
 import { useToday } from "@/hooks/useToday"
 import { type CalendarEvent } from "@/lib/cal-events"
@@ -19,12 +20,13 @@ interface Bucket {
 
 export function BoardView() {
   const { calendarEvents } = useCalEvents()
+  const { firstDayOfWeek } = useSettings()
   const today = useToday()
 
   const columns = useMemo(() => {
     const yesterday = today.subtract({ days: 1 })
     const tomorrow = today.add({ days: 1 })
-    const endOfWeek = startOfWeek(today).add({ days: 6 })
+    const endOfWeek = startOfWeek(today, firstDayOfWeek).add({ days: 6 })
 
     function getBucketId(pd: Temporal.PlainDate): string {
       if (pd.equals(yesterday)) return "yesterday"
@@ -79,7 +81,7 @@ export function BoardView() {
         isToday: def.isToday,
       } satisfies Bucket
     })
-  }, [calendarEvents, today])
+  }, [calendarEvents, today, firstDayOfWeek])
 
   return (
     <div className="flex h-full overflow-hidden">

--- a/src/components/main/month-view/WeekDayLabels.tsx
+++ b/src/components/main/month-view/WeekDayLabels.tsx
@@ -1,16 +1,24 @@
+import { useSettings } from "@/contexts/SettingsContext"
+
+import type { FirstDayOfWeek } from "@/lib/event-time"
 import { cn } from "@/lib/utils"
 
-const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+const WEEKDAY_LABELS: Record<FirstDayOfWeek, string[]> = {
+  monday: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+  sunday: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+}
 
 export const WeekDayLabels = ({ dimmed }: { dimmed: boolean }) => {
+  const { firstDayOfWeek } = useSettings()
+
   return (
     <div className="grid grid-cols-7 border-b border-divider">
-      {WEEKDAY_LABELS.map((label, i) => (
+      {WEEKDAY_LABELS[firstDayOfWeek].map((label) => (
         <div
           key={label}
           className={cn(
             "text-[11px]! text-muted-foreground py-2 text-center font-medium numerical uppercase",
-            i >= 5 && "bg-weekend",
+            (label === "Sat" || label === "Sun") && "bg-weekend",
             dimmed && "opacity-50",
           )}
         >

--- a/src/components/main/month-view/pickActiveMonth.test.ts
+++ b/src/components/main/month-view/pickActiveMonth.test.ts
@@ -10,7 +10,7 @@ const ROW = 100
 
 // Weeks starting from the Monday of `startMonday`'s week, mirroring useMonthGrid.
 function buildWeeks(startMonday: Temporal.PlainDate, numWeeks: number): MonthDay[][] {
-  const mon = startOfWeek(startMonday)
+  const mon = startOfWeek(startMonday, "monday")
   return Array.from({ length: numWeeks }, (_, w) =>
     Array.from({ length: 7 }, (_, d) => {
       const date = mon.add({ days: w * 7 + d })

--- a/src/components/main/month-view/useInfiniteMonths.tsx
+++ b/src/components/main/month-view/useInfiniteMonths.tsx
@@ -2,6 +2,7 @@ import { Temporal } from "@js-temporal/polyfill"
 import { RefObject, useCallback, useEffect, useState } from "react"
 
 import { useCalEvents } from "@/contexts/CalEventsContext"
+import { useSettings } from "@/contexts/SettingsContext"
 
 import { monthGridBounds } from "@/hooks/cal-events/useMonthGrid"
 import { useScrollBoundary } from "@/hooks/useScrollBoundary"
@@ -32,6 +33,7 @@ export function useInfiniteMonths({
   visibleCalendarIds: string[]
 }) {
   const { ensureRangeLoaded } = useCalEvents()
+  const { firstDayOfWeek } = useSettings()
 
   const [rangeStart, setRangeStart] = useState(() => rangeStartFor(activeDate))
   const [rangeEnd, setRangeEnd] = useState(() => rangeEndFor(activeDate))
@@ -48,10 +50,10 @@ export function useInfiniteMonths({
   // Keep loaded events in step with the rendered weeks.
   const visibleCalendarKey = visibleCalendarIds.join("|")
   useEffect(() => {
-    const { gridStart, gridEnd } = monthGridBounds(rangeStart, rangeEnd)
+    const { gridStart, gridEnd } = monthGridBounds(rangeStart, rangeEnd, firstDayOfWeek)
     debugMonthScroll("ensure month range loaded", { gridStart, gridEnd })
     void ensureRangeLoaded(gridStart, gridEnd)
-  }, [rangeStart, rangeEnd, visibleCalendarKey, ensureRangeLoaded])
+  }, [rangeStart, rangeEnd, visibleCalendarKey, ensureRangeLoaded, firstDayOfWeek])
 
   useScrollBoundary({
     scrollContainerRef,

--- a/src/components/main/week-view/WeekTimeGrid.tsx
+++ b/src/components/main/week-view/WeekTimeGrid.tsx
@@ -21,6 +21,7 @@ import {
   formatWeekday,
   getViewerTzid,
   startOfWeek,
+  type FirstDayOfWeek,
 } from "@/lib/event-time"
 import { isDeclinedEvent, isPendingEvent } from "@/lib/event-utils"
 import { cn } from "@/lib/utils"
@@ -38,9 +39,13 @@ const DAY_WIDTH_MIN = 100
 // and updating the activeDate based on the scroll position.
 const SCROLL_SETTLE_MS = 300
 
-function mondayIndex(days: MonthDay[], activeDay: MonthDay): number {
-  const monday = startOfWeek(activeDay.date)
-  return days.findIndex((day) => day.date.equals(monday))
+function weekStartIndex(
+  days: MonthDay[],
+  activeDay: MonthDay,
+  firstDayOfWeek: FirstDayOfWeek,
+): number {
+  const weekStart = startOfWeek(activeDay.date, firstDayOfWeek)
+  return days.findIndex((day) => day.date.equals(weekStart))
 }
 
 type WeekTimeGridProps = {
@@ -75,7 +80,7 @@ export function WeekTimeGrid({
   dimmed,
 }: WeekTimeGridProps) {
   const { calendars } = useCalendars()
-  const { timeFormat } = useSettings()
+  const { timeFormat, firstDayOfWeek, settingsLoaded } = useSettings()
   const openDayDraft = useOpenDayDraft()
 
   const N = days.length
@@ -126,10 +131,12 @@ export function WeekTimeGrid({
     }
   })
 
-  // Initial scroll (once dayWidth is measured): scrollTop to current time / 08:00, scrollLeft to Monday of activeDate's week.
+  // Initial scroll (once dayWidth is measured and settings are loaded, since week
+  // alignment depends on firstDayOfWeek): scrollTop to current time / 08:00,
+  // scrollLeft to the first day of activeDate's week.
   const didInitialScrollRef = useRef(false)
   useLayoutEffect(() => {
-    if (!dayWidthReady || didInitialScrollRef.current) return
+    if (!dayWidthReady || !settingsLoaded || didInitialScrollRef.current) return
     const el = scrollContainerRef.current
     if (!el) return
 
@@ -141,12 +148,20 @@ export function WeekTimeGrid({
 
     const activeDay = days.find((d) => d.dateKey === activeDateKey)
     if (activeDay) {
-      const mondayIdx = mondayIndex(days, activeDay)
-      if (mondayIdx !== -1) el.scrollLeft = mondayIdx * dayWidth
+      const weekStartIdx = weekStartIndex(days, activeDay, firstDayOfWeek)
+      if (weekStartIdx !== -1) el.scrollLeft = weekStartIdx * dayWidth
     }
 
     didInitialScrollRef.current = true
-  }, [dayWidthReady, days, dayWidth, activeDateKey, scrollContainerRef])
+  }, [
+    dayWidthReady,
+    settingsLoaded,
+    days,
+    dayWidth,
+    activeDateKey,
+    firstDayOfWeek,
+    scrollContainerRef,
+  ])
 
   // After initial scroll, whenever activeDate changes to an off-screen day, smooth-scroll it into view.
   // Deps are intentionally only activeDateKey — if we include `days` / `dayWidth`, the effect
@@ -171,8 +186,8 @@ export function WeekTimeGrid({
 
     if (columnLeft < viewportLeft - 1 || columnRight > viewportRight + 1) {
       const activeDay = currentDays[idx]
-      const mondayIdx = mondayIndex(currentDays, activeDay)
-      const targetIdx = mondayIdx !== -1 ? mondayIdx : idx
+      const weekStartIdx = weekStartIndex(currentDays, activeDay, firstDayOfWeek)
+      const targetIdx = weekStartIdx !== -1 ? weekStartIdx : idx
 
       suppressScrollTracking()
       el.scrollTo({ left: targetIdx * currentDayWidth, behavior: "smooth" })

--- a/src/components/settings/general/GeneralPage.tsx
+++ b/src/components/settings/general/GeneralPage.tsx
@@ -19,12 +19,14 @@ import type { TimeFormat } from "@/rpc/bindings"
 
 import { useSettings } from "@/contexts/SettingsContext"
 
+import type { FirstDayOfWeek } from "@/lib/event-time"
 import { checkForUpdate, promptAndInstall, type Update } from "@/lib/updater"
 
 export function GeneralPage() {
   return (
     <SettingsContent>
       <TimeFormatSection />
+      <FirstDayOfWeekSection />
       <DataDirectorySection />
       <AutoSyncSection />
       <hr />
@@ -46,6 +48,25 @@ const TimeFormatSection = () => {
         <SelectContent>
           <SelectItem value="24h">24h</SelectItem>
           <SelectItem value="12h">12h</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+const FirstDayOfWeekSection = () => {
+  const { firstDayOfWeek, setFirstDayOfWeek } = useSettings()
+
+  return (
+    <div className="flex flex-col gap-2 w-[150px]">
+      <label className="text-sm">First day of week</label>
+      <Select value={firstDayOfWeek} onValueChange={(v) => setFirstDayOfWeek(v as FirstDayOfWeek)}>
+        <SelectTrigger className="w-full" ghost={false}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="monday">Monday</SelectItem>
+          <SelectItem value="sunday">Sunday</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/components/sidebar/minical/Calendar.tsx
+++ b/src/components/sidebar/minical/Calendar.tsx
@@ -14,6 +14,8 @@ import {
 
 import { Button, buttonVariants } from "@/components/ui/button"
 
+import { useSettings } from "@/contexts/SettingsContext"
+
 import { useViewerTzid } from "@/hooks/useViewerTzid"
 import { formatDateKey, today } from "@/lib/event-time"
 import { jsDateToPlainDate, plainDateToJsDate } from "@/lib/event-time/js-date"
@@ -45,6 +47,7 @@ function Calendar({
   buttonVariant?: ComponentProps<typeof Button>["variant"]
 }) {
   const defaultClassNames = getDefaultClassNames()
+  const { firstDayOfWeek } = useSettings()
 
   // Subscribe to timezone changes: the current-week/weekday highlights and the
   // `today` prop below all derive from the viewer's zone.
@@ -61,7 +64,7 @@ function Calendar({
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,
       )}
-      weekStartsOn={1}
+      weekStartsOn={firstDayOfWeek === "sunday" ? 0 : 1}
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) => date.toLocaleString("default", { month: "short" }),

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -3,6 +3,8 @@ import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
 
 import { Button, buttonVariants } from "@/components/ui/button"
 
+import { useSettings } from "@/contexts/SettingsContext"
+
 import { cn } from "@/lib/utils"
 
 import { ChevronDownIcon } from "@/icons/chevron-down"
@@ -22,11 +24,12 @@ function Calendar({
   buttonVariant?: React.ComponentProps<typeof Button>["variant"]
 }) {
   const defaultClassNames = getDefaultClassNames()
+  const { firstDayOfWeek } = useSettings()
 
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      weekStartsOn={1}
+      weekStartsOn={firstDayOfWeek === "sunday" ? 0 : 1}
       className={cn(
         "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -12,10 +12,13 @@ import {
 } from "@/rpc/events"
 
 import { normalizeCalendarGroups } from "@/lib/calendar-groups"
+import type { FirstDayOfWeek } from "@/lib/event-time"
 
 interface SettingsContextType {
   timeFormat: TimeFormat
   setTimeFormat: (tf: TimeFormat) => Promise<void>
+  firstDayOfWeek: FirstDayOfWeek
+  setFirstDayOfWeek: (day: FirstDayOfWeek) => Promise<void>
   defaultReminders: number[]
   setDefaultReminders: (mins: number[]) => Promise<void>
   defaultCalendar: string | null
@@ -43,6 +46,7 @@ export function useSettings() {
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [timeFormat, setTimeFormatState] = useState<TimeFormat>("24h")
+  const [firstDayOfWeek, setFirstDayOfWeekState] = useState<FirstDayOfWeek>("monday")
   const [defaultReminders, setDefaultRemindersState] = useState<number[]>([])
   const [defaultCalendar, setDefaultCalendarState] = useState<string | null>(null)
   const [calendarDir, setCalendarDirState] = useState<string>("")
@@ -53,21 +57,25 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const reloadSettings = useCallback(async () => {
     try {
-      const [tf, reminders, cal, dir, notifs, autoSync, groupsResult] = await Promise.all([
-        rpc.caldir.get_time_format(),
-        rpc.caldir.get_default_reminders(),
-        rpc.caldir.get_default_calendar(),
-        rpc.caldir.get_calendar_dir(),
-        rpc.config.get_notifications_enabled(),
-        rpc.config.get_auto_sync_enabled(),
-        rpc.config.get_groups(),
-      ])
+      const [tf, reminders, cal, dir, notifs, autoSync, firstDay, groupsResult] = await Promise.all(
+        [
+          rpc.caldir.get_time_format(),
+          rpc.caldir.get_default_reminders(),
+          rpc.caldir.get_default_calendar(),
+          rpc.caldir.get_calendar_dir(),
+          rpc.config.get_notifications_enabled(),
+          rpc.config.get_auto_sync_enabled(),
+          rpc.config.get_first_day_of_week(),
+          rpc.config.get_groups(),
+        ],
+      )
       setTimeFormatState(tf)
       setDefaultRemindersState(reminders)
       setDefaultCalendarState(cal)
       setCalendarDirState(dir)
       setNotificationsEnabledState(notifs)
       setAutoSyncEnabledState(autoSync)
+      setFirstDayOfWeekState(firstDay)
       // The RPC type is Partial<Record<string, string[]>>; drop undefined values.
       setGroupsState(normalizeCalendarGroups(groupsResult))
       setSettingsLoaded(true)
@@ -138,6 +146,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     await emit(RENCAL_CONFIG_CHANGED)
   }
 
+  const setFirstDayOfWeek = async (day: FirstDayOfWeek) => {
+    setFirstDayOfWeekState(day)
+    await rpc.config.set_first_day_of_week(day)
+    await emit(RENCAL_CONFIG_CHANGED)
+  }
+
   const setAutoSyncEnabled = async (enabled: boolean) => {
     setAutoSyncEnabledState(enabled)
     await rpc.config.set_auto_sync_enabled(enabled)
@@ -155,6 +169,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         timeFormat,
         setTimeFormat,
+        firstDayOfWeek,
+        setFirstDayOfWeek,
         defaultReminders,
         setDefaultReminders,
         defaultCalendar,

--- a/src/hooks/cal-events/useInfiniteDays.ts
+++ b/src/hooks/cal-events/useInfiniteDays.ts
@@ -2,27 +2,31 @@ import { Temporal } from "@js-temporal/polyfill"
 import { RefObject, useCallback, useEffect, useMemo, useState } from "react"
 
 import { useCalEvents } from "@/contexts/CalEventsContext"
+import { useSettings } from "@/contexts/SettingsContext"
 
 import { useScrollBoundary } from "@/hooks/useScrollBoundary"
 import { useToday } from "@/hooks/useToday"
-import { startOfWeek } from "@/lib/event-time"
+import { startOfWeek, type FirstDayOfWeek } from "@/lib/event-time"
 
 import { buildDay, type MonthDay } from "./useMonthGrid"
 
 const BUFFER_DAYS = 7
 const INITIAL_RANGE_DAYS = 21
 
-/** Seed the day range: activeDate's Mon–Sun week, with BUFFER_DAYS extra on each side. */
-function initialRangeStart(activeDate: Temporal.PlainDate): Temporal.PlainDate {
-  return startOfWeek(activeDate).subtract({ days: BUFFER_DAYS })
+/** Seed the day range: activeDate's week, with BUFFER_DAYS extra on each side. */
+function initialRangeStart(
+  activeDate: Temporal.PlainDate,
+  firstDayOfWeek: FirstDayOfWeek,
+): Temporal.PlainDate {
+  return startOfWeek(activeDate, firstDayOfWeek).subtract({ days: BUFFER_DAYS })
 }
 
 /**
  * Manages a growing range of days for the continuously-scrollable week view. The day range
  * is the source of truth for what's rendered; event loading just follows it via
  * `ensureRangeLoaded` and never blocks scrolling (mirrors useInfiniteMonths).
- * Start is a Monday (activeDate's week Monday, minus one buffer week); new weeks are
- * prepended/appended when the user scrolls within `threshold` px of either edge.
+ * Start is aligned to the first day of activeDate's week (minus one buffer week); new
+ * weeks are prepended/appended when the user scrolls within `threshold` px of either edge.
  */
 export function useInfiniteDays({
   scrollContainerRef,
@@ -34,9 +38,10 @@ export function useInfiniteDays({
   visibleCalendarIds: string[]
 }): { days: MonthDay[] } {
   const { ensureRangeLoaded } = useCalEvents()
+  const { firstDayOfWeek } = useSettings()
   const today = useToday()
 
-  const [rangeStart, setRangeStart] = useState(() => initialRangeStart(activeDate))
+  const [rangeStart, setRangeStart] = useState(() => initialRangeStart(activeDate, firstDayOfWeek))
   const [count, setCount] = useState(INITIAL_RANGE_DAYS)
 
   // If activeDate jumps outside the rendered range, reset around it.
@@ -45,7 +50,7 @@ export function useInfiniteDays({
     Temporal.PlainDate.compare(activeDate, rangeStart) < 0 ||
     Temporal.PlainDate.compare(activeDate, rangeEnd) > 0
   ) {
-    const newStart = initialRangeStart(activeDate)
+    const newStart = initialRangeStart(activeDate, firstDayOfWeek)
     if (!newStart.equals(rangeStart) || count !== INITIAL_RANGE_DAYS) {
       setRangeStart(newStart)
       setCount(INITIAL_RANGE_DAYS)

--- a/src/hooks/cal-events/useMonthGrid.ts
+++ b/src/hooks/cal-events/useMonthGrid.ts
@@ -1,8 +1,10 @@
 import { Temporal } from "@js-temporal/polyfill"
 import { useMemo } from "react"
 
+import { useSettings } from "@/contexts/SettingsContext"
+
 import { useToday } from "@/hooks/useToday"
-import { formatDateKey, startOfWeek } from "@/lib/event-time"
+import { formatDateKey, startOfWeek, type FirstDayOfWeek } from "@/lib/event-time"
 
 export type MonthDay = {
   date: Temporal.PlainDate
@@ -23,8 +25,12 @@ export function buildDay(date: Temporal.PlainDate, today: Temporal.PlainDate): M
 export function monthGridBounds(
   rangeStart: Temporal.PlainDate,
   rangeEnd: Temporal.PlainDate,
+  firstDayOfWeek: FirstDayOfWeek,
 ): { gridStart: Temporal.PlainDate; gridEnd: Temporal.PlainDate } {
-  return { gridStart: startOfWeek(rangeStart), gridEnd: startOfWeek(rangeEnd) }
+  return {
+    gridStart: startOfWeek(rangeStart, firstDayOfWeek),
+    gridEnd: startOfWeek(rangeEnd, firstDayOfWeek),
+  }
 }
 
 /**
@@ -33,9 +39,10 @@ export function monthGridBounds(
  */
 export function useMonthGrid(rangeStart: Temporal.PlainDate, rangeEnd: Temporal.PlainDate) {
   const today = useToday()
+  const { firstDayOfWeek } = useSettings()
 
   return useMemo(() => {
-    const { gridStart, gridEnd } = monthGridBounds(rangeStart, rangeEnd)
+    const { gridStart, gridEnd } = monthGridBounds(rangeStart, rangeEnd, firstDayOfWeek)
 
     const weeks: MonthDay[][] = []
     let current = gridStart
@@ -51,5 +58,5 @@ export function useMonthGrid(rangeStart: Temporal.PlainDate, rangeEnd: Temporal.
     }
 
     return weeks
-  }, [rangeStart, rangeEnd, today])
+  }, [rangeStart, rangeEnd, today, firstDayOfWeek])
 }

--- a/src/lib/event-time.test.ts
+++ b/src/lib/event-time.test.ts
@@ -8,6 +8,7 @@ import {
   enumerateLocalDays,
   epochDay,
   formatDateKey,
+  startOfWeek,
   computeEventDateInfo,
   getViewerTzid,
   setViewerTzid,
@@ -462,5 +463,28 @@ describe("viewer zone store", () => {
     } finally {
       setViewerTzid(original)
     }
+  })
+})
+
+describe("startOfWeek", () => {
+  // 2024-01-01 was a Monday.
+  const monday = Temporal.PlainDate.from("2024-01-01")
+  const wednesday = Temporal.PlainDate.from("2024-01-03")
+  const saturday = Temporal.PlainDate.from("2024-01-06")
+  const sunday = Temporal.PlainDate.from("2024-01-07")
+
+  it("returns the preceding (or same) Monday when weeks start on Monday", () => {
+    expect(startOfWeek(monday, "monday").equals(monday)).toBe(true)
+    expect(startOfWeek(wednesday, "monday").equals(monday)).toBe(true)
+    expect(startOfWeek(sunday, "monday").equals(monday)).toBe(true)
+  })
+
+  it("returns the preceding (or same) Sunday when weeks start on Sunday", () => {
+    const previousSunday = Temporal.PlainDate.from("2023-12-31")
+    expect(startOfWeek(previousSunday, "sunday").equals(previousSunday)).toBe(true)
+    expect(startOfWeek(monday, "sunday").equals(previousSunday)).toBe(true)
+    expect(startOfWeek(wednesday, "sunday").equals(previousSunday)).toBe(true)
+    expect(startOfWeek(saturday, "sunday").equals(previousSunday)).toBe(true)
+    expect(startOfWeek(sunday, "sunday").equals(sunday)).toBe(true)
   })
 })

--- a/src/lib/event-time/day.ts
+++ b/src/lib/event-time/day.ts
@@ -7,9 +7,17 @@ export function epochDay(date: Temporal.PlainDate): number {
   return date.toZonedDateTime("UTC").epochMilliseconds / MILLIS_PER_DAY
 }
 
-/** The Monday that begins the week containing the given date. */
-export function startOfWeek(date: Temporal.PlainDate): Temporal.PlainDate {
-  return date.subtract({ days: date.dayOfWeek - 1 })
+/** App-level mirror of the RPC `FirstDayOfWeek` type. */
+export type FirstDayOfWeek = "monday" | "sunday"
+
+/** The day that begins the week containing the given date, per `firstDay`. */
+export function startOfWeek(
+  date: Temporal.PlainDate,
+  firstDay: FirstDayOfWeek,
+): Temporal.PlainDate {
+  // dayOfWeek: Mon=1 … Sun=7.
+  const daysSinceWeekStart = firstDay === "sunday" ? date.dayOfWeek % 7 : date.dayOfWeek - 1
+  return date.subtract({ days: daysSinceWeekStart })
 }
 
 /** Parse the app's YYYY-MM-DD day-key representation. */

--- a/src/lib/event-time/index.ts
+++ b/src/lib/event-time/index.ts
@@ -23,7 +23,7 @@ export {
   WEEK_MINUTES,
 } from "./constants"
 export { allDayDate, atTime, fromDate, nowZoned, today } from "./constructors"
-export { dateKeyToPlainDate, epochDay, startOfWeek } from "./day"
+export { dateKeyToPlainDate, epochDay, startOfWeek, type FirstDayOfWeek } from "./day"
 export {
   formatDateKey,
   formatDayMonth,

--- a/src/rpc/bindings.ts
+++ b/src/rpc/bindings.ts
@@ -36,6 +36,12 @@ export type ExternalTheme = { id: string;
  */
 name: string; css: string }
 
+/**
+ * RPC mirror of `rencal_config::FirstDayOfWeek` (the config crate stays free
+ * of specta/taurpc so the notifier daemon can depend on it).
+ */
+export type FirstDayOfWeek = "monday" | "sunday"
+
 export type OmarchyColors = { mode: OmarchyMode; background: string; foreground: string; bright_foreground: string; accent: string; red: string; green: string; yellow: string; blue: string }
 
 export type OmarchyMode = "dark" | "light"
@@ -114,7 +120,7 @@ export type UpdateEventInput = { id: string; calendar_slug: string;
  */
 new_calendar_slug: string | null; summary: string; description: string | null; location: string | null; start: RpcEventTime; end: RpcEventTime; recurrence: RpcRecurrence | null; reminders: number[]; attendees: EventAttendee[]; conference: EventConference | null }
 
-const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_calendar":["calendar_slug"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"find_event":["uid","recurrence_id"],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_contacts":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rename_calendar":["calendar_slug","name"],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_color":["calendar_slug","color"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_groups":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_groups":["groups"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[],"take_pending_event_links":[]}', 'themes':'{"list_external":[]}' }
+const ARGS_MAP = { 'caldir':'{"check_provider_connection":["provider_name","account"],"connect_provider":["provider_name"],"connect_provider_with_credentials":["provider_name","credentials"],"create_event":["input"],"create_local_calendar":["name","color"],"delete_calendar":["calendar_slug"],"delete_event":["calendar_slug","event_id"],"delete_recurring_series":["calendar_slug","uid"],"discard":[],"find_event":["uid","recurrence_id"],"get_calendar_dir":[],"get_default_calendar":[],"get_default_reminders":[],"get_event":["calendar_slug","event_id"],"get_provider_connect_info":["provider_name"],"get_time_format":[],"list_calendars":[],"list_contacts":[],"list_events":["calendar_slugs","start","end"],"list_invites":["calendar_slugs"],"list_providers":[],"rename_calendar":["calendar_slug","name"],"rsvp":["calendar_slug","event_id","response"],"search_events":["calendar_slugs","query"],"set_calendar_color":["calendar_slug","color"],"set_calendar_dir":["path"],"set_default_calendar":["slug"],"set_default_reminders":["minutes"],"set_time_format":["time_format"],"split_recurring_series_at":["input"],"sync":["allow_mass_delete"],"sync_preview":[],"update_event":["input"]}', 'config':'{"get_auto_sync_enabled":[],"get_first_day_of_week":[],"get_groups":[],"get_notifications_enabled":[],"get_theme":[],"set_auto_sync_enabled":["enabled"],"set_first_day_of_week":["day"],"set_groups":["groups"],"set_notifications_enabled":["enabled"],"set_theme":["theme"]}', 'omarchy':'{"get_colors":[]}', 'platform':'{"needs_native_decorations":[],"take_pending_event_links":[]}', 'themes':'{"list_external":[]}' }
 export type Router = { "caldir": {check_provider_connection: (providerName: string, account: string) => Promise<null>, 
 connect_provider: (providerName: string) => Promise<Calendar[]>, 
 connect_provider_with_credentials: (providerName: string, credentials: CredentialFieldInput[]) => Promise<Calendar[]>, 
@@ -149,10 +155,12 @@ sync: (allowMassDelete: string[]) => Promise<null>,
 sync_preview: () => Promise<SyncPreview[]>, 
 update_event: (input: UpdateEventInput) => Promise<null>},
 "config": {get_auto_sync_enabled: () => Promise<boolean>, 
+get_first_day_of_week: () => Promise<FirstDayOfWeek>, 
 get_groups: () => Promise<Partial<{ [key in string]: string[] }>>, 
 get_notifications_enabled: () => Promise<boolean>, 
 get_theme: () => Promise<string | null>, 
 set_auto_sync_enabled: (enabled: boolean) => Promise<null>, 
+set_first_day_of_week: (day: FirstDayOfWeek) => Promise<null>, 
 set_groups: (groups: Partial<{ [key in string]: string[] }>) => Promise<null>, 
 set_notifications_enabled: (enabled: boolean) => Promise<null>, 
 set_theme: (theme: string) => Promise<null>},


### PR DESCRIPTION
Closes #111

Adds a **"First day of week"** option (Monday default, or Sunday) to Settings → General, stored as `first_day_of_week` in `config.toml` per the suggestion in #111.

## What it does

- **`RencalConfig`**: new `first_day_of_week` property (`"monday"` | `"sunday"`, defaults to `"monday"`, `#[serde(default)]` so existing configs are untouched). The RPC layer mirrors it as a specta enum (same pattern as `TimeFormat`) so the config crate stays free of taurpc for the notifier daemon.
- **Week view**: infinite-scroll seeding and scroll snapping align to the configured first day. The initial scroll now also waits for `settingsLoaded` so it doesn't snap to Monday before the config arrives.
- **Month view**: grid weeks and the weekday label row follow the setting (weekend tint stays on Sat/Sun).
- **Mini calendars** (sidebar minical + date picker): `weekStartsOn` follows the setting.
- **Board view**: the "This Week" bucket ends on the configured week's last day.
- `startOfWeek()` now takes a required `FirstDayOfWeek` argument so no call site can silently keep a Monday assumption.

## Testing

- `just check`, `just typecheck`, `pnpm test` (91 passing, incl. new `startOfWeek` tests), `cargo test -p rencal-config` (new default/round-trip test).
- Tested live in `tauri dev`: toggling the new select re-renders month/week/minical immediately, hand-editing `config.toml` hot-reloads via the config watcher, and existing configs without the key default to Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)