### PR TITLE
Add Themes Playground to website

### DIFF
--- a/website/src/components/landing/Header.astro
+++ b/website/src/components/landing/Header.astro
@@ -29,8 +29,8 @@ import MenuBars from "../MenuBars.astro"
   >
     <a href="/download">Download</a>
     <a href="/themes">Themes</a>
-    <a href="/docs/installation">Docs</a>
     <a href="/changelog">Changelog</a>
+    <a href="/docs/installation">Docs</a>
     <a href="https://github.com/t4t5/rencal" target="_blank" aria-label="GitHub repo">
       <span class="sm:hidden">GitHub</span>
       <GitHubLogo class="hidden sm:block w-6" />

--- a/website/src/components/landing/Header.astro
+++ b/website/src/components/landing/Header.astro
@@ -28,6 +28,7 @@ import MenuBars from "../MenuBars.astro"
     class="hidden absolute top-full inset-x-0 z-50 flex-col gap-5 px-6 py-5 bg-background border-b border-white/10 uppercase text-foreground [&>a:hover]:underline sm:static sm:flex sm:flex-row sm:items-center sm:gap-7 sm:p-0 sm:border-none"
   >
     <a href="/download">Download</a>
+    <a href="/themes">Themes</a>
     <a href="/docs/installation">Docs</a>
     <a href="/changelog">Changelog</a>
     <a href="https://github.com/t4t5/rencal" target="_blank" aria-label="GitHub repo">

--- a/website/src/components/themes/AppPreview.astro
+++ b/website/src/components/themes/AppPreview.astro
@@ -184,9 +184,9 @@ const barStyle = (bar: AllDayBar) =>
   id="rc-preview"
   class="rc-scope flex h-[620px] cursor-default overflow-hidden rounded-xl border border-white/10 bg-(--background) text-[16px] leading-6 text-(--foreground) antialiased select-none"
 >
-  <!-- Sidebar -->
+  <!-- Sidebar (the only pane on narrow widths; fixed-width next to Main on xl+) -->
   <div
-    class="hidden w-[280px] shrink-0 flex-col overflow-hidden border-r border-(--divider) xl:flex"
+    class="flex grow flex-col overflow-hidden xl:w-[280px] xl:grow-0 xl:shrink-0 xl:border-r xl:border-(--divider)"
   >
     <!-- Toolbar with the compose (+) button -->
     <div class="flex justify-end p-4 pb-0">
@@ -337,7 +337,7 @@ const barStyle = (bar: AllDayBar) =>
   </div>
 
   <!-- Main -->
-  <div class="flex min-w-0 grow flex-col">
+  <div class="hidden min-w-0 grow flex-col xl:flex">
     <!-- Header -->
     <div class="flex shrink-0 items-center gap-2 p-4">
       <span class="rc-btn">Today</span>

--- a/website/src/components/themes/AppPreview.astro
+++ b/website/src/components/themes/AppPreview.astro
@@ -1,0 +1,475 @@
+---
+// A simplified, static mock of the renCal app window, rendered entirely from
+// the theme variables defined by the `.rc-scope` class (src/styles/themes.css).
+// The layout and class recipes mirror the real app components (MainHeader,
+// Minical, Agenda, MonthView) in ../../../../src (simplified — no interactivity).
+
+// Fixed calendar colors, like a user's multi-calendar setup. Events without a
+// color fall back to var(--primary), matching the app's default calendar color.
+const PURPLE = "#9d7cd8"
+const GREEN = "#4caf50"
+
+interface Chip {
+  time: string
+  title: string
+  color?: string
+}
+
+interface Day {
+  num: number
+  monthLabel?: string
+  weekend?: boolean
+  today?: boolean
+  active?: boolean
+  /** Reserve space for an all-day bar lane above the timed chips. */
+  spacer?: boolean
+  chips?: Chip[]
+  more?: number
+}
+
+interface AllDayBar {
+  /** 1-indexed columns, endCol exclusive (same convention as the app). */
+  startCol: number
+  endCol: number
+  title: string
+  color?: string
+}
+
+interface Week {
+  days: Day[]
+  bars?: AllDayBar[]
+  /** 0-indexed column where a new month starts (vertical boundary line). */
+  boundaryCol?: number
+}
+
+// August 2026, Monday start, today = Friday Aug 28.
+const weeks: Week[] = [
+  {
+    days: [
+      { num: 10, chips: [{ time: "09:00", title: "Standup" }] },
+      { num: 11, chips: [{ time: "07:00", title: "Gym", color: GREEN }] },
+      { num: 12, chips: [{ time: "12:30", title: "Lunch w/ Sam" }] },
+      {
+        num: 13,
+        chips: [
+          { time: "09:00", title: "Standup" },
+          { time: "15:00", title: "Design review", color: PURPLE },
+        ],
+      },
+      { num: 14 },
+      { num: 15, weekend: true, chips: [{ time: "10:00", title: "Market run", color: GREEN }] },
+      { num: 16, weekend: true },
+    ],
+  },
+  {
+    days: [
+      { num: 17, chips: [{ time: "09:00", title: "Standup" }] },
+      {
+        num: 18,
+        chips: [
+          { time: "07:00", title: "Gym", color: GREEN },
+          { time: "14:00", title: "1:1 w/ Dana" },
+        ],
+      },
+      { num: 19, chips: [{ time: "18:30", title: "Dinner w/ Alex", color: PURPLE }] },
+      { num: 20, chips: [{ time: "09:00", title: "Standup" }] },
+      { num: 21, chips: [{ time: "16:00", title: "Demo day" }] },
+      { num: 22, weekend: true },
+      { num: 23, weekend: true, chips: [{ time: "11:00", title: "Hike", color: GREEN }] },
+    ],
+  },
+  {
+    bars: [{ startCol: 3, endCol: 6, title: "Conference", color: PURPLE }],
+    days: [
+      { num: 24, chips: [{ time: "09:00", title: "Standup" }] },
+      { num: 25, chips: [{ time: "07:00", title: "Gym", color: GREEN }] },
+      { num: 26, spacer: true, chips: [{ time: "13:00", title: "Workshop", color: PURPLE }] },
+      { num: 27, spacer: true },
+      {
+        num: 28,
+        today: true,
+        active: true,
+        spacer: true,
+        chips: [
+          { time: "09:30", title: "Keynote", color: PURPLE },
+          { time: "19:00", title: "Team dinner" },
+        ],
+        more: 2,
+      },
+      { num: 29, weekend: true, chips: [{ time: "08:00", title: "Long run", color: GREEN }] },
+      { num: 30, weekend: true },
+    ],
+  },
+  {
+    boundaryCol: 1,
+    bars: [{ startCol: 6, endCol: 8, title: "Berlin trip", color: GREEN }],
+    days: [
+      { num: 31, chips: [{ time: "09:00", title: "Standup" }] },
+      { num: 1, monthLabel: "September", chips: [{ time: "07:00", title: "Gym", color: GREEN }] },
+      { num: 2, chips: [{ time: "12:30", title: "Lunch w/ Sam" }] },
+      { num: 3, chips: [{ time: "09:00", title: "Standup" }] },
+      { num: 4, chips: [{ time: "16:00", title: "Demo day" }] },
+      { num: 5, weekend: true, spacer: true },
+      { num: 6, weekend: true, spacer: true },
+    ],
+  },
+]
+
+const weekdayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+// Minical grid: Jul 27 – Sep 6 chunked into weeks.
+interface MiniDay {
+  num: number
+  outside?: boolean
+}
+
+const miniCells: MiniDay[] = []
+for (let d = 27; d <= 31; d++) miniCells.push({ num: d, outside: true })
+for (let d = 1; d <= 31; d++) miniCells.push({ num: d })
+for (let d = 1; d <= 6; d++) miniCells.push({ num: d, outside: true })
+
+const miniWeeks: MiniDay[][] = []
+for (let i = 0; i < miniCells.length; i += 7) miniWeeks.push(miniCells.slice(i, i + 7))
+const CURRENT_WEEK_INDEX = 4
+
+const miniDots: Record<number, string[]> = {
+  24: ["var(--primary)"],
+  25: [GREEN],
+  26: [PURPLE],
+  27: [PURPLE],
+  28: [PURPLE, "var(--primary)"],
+  29: [GREEN],
+  31: ["var(--primary)"],
+}
+
+interface AgendaSection {
+  label: string
+  date: string
+  today?: boolean
+  allDay?: { title: string; color?: string }[]
+  rows: { time: string; title: string; color?: string }[]
+}
+
+const agenda: AgendaSection[] = [
+  {
+    label: "Today",
+    date: "28 Aug",
+    today: true,
+    allDay: [{ title: "Conference", color: PURPLE }],
+    rows: [
+      { time: "09:30 - 10:15", title: "Keynote", color: PURPLE },
+      { time: "12:00 - 12:45", title: "Lunch w/ Sam" },
+      { time: "19:00 - 21:00", title: "Team dinner" },
+    ],
+  },
+  {
+    label: "Tomorrow",
+    date: "29 Aug",
+    rows: [{ time: "08:00 - 09:30", title: "Long run", color: GREEN }],
+  },
+  { label: "Sunday", date: "30 Aug", rows: [] },
+]
+
+const barStyle = (bar: AllDayBar) =>
+  [
+    bar.color ? `--ev: ${bar.color}` : null,
+    `left: calc(${(((bar.startCol - 1) / 7) * 100).toFixed(4)}% + 3px)`,
+    `right: calc(${(((7 - (bar.endCol - 1)) / 7) * 100).toFixed(4)}% + 4px)`,
+  ]
+    .filter(Boolean)
+    .join("; ")
+---
+
+<div
+  id="rc-preview"
+  class="rc-scope flex h-[620px] cursor-default overflow-hidden rounded-xl border border-white/10 bg-(--background) text-[16px] leading-6 text-(--foreground) antialiased select-none"
+>
+  <!-- Sidebar -->
+  <div
+    class="hidden w-[280px] shrink-0 flex-col overflow-hidden border-r border-(--divider) xl:flex"
+  >
+    <!-- Toolbar with the compose (+) button -->
+    <div class="flex justify-end p-4 pb-0">
+      <span class="rc-btn rc-btn--icon">
+        <svg viewBox="0 0 24 24" class="size-4" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 5v14M5 12h14" stroke-linecap="round"></path>
+        </svg>
+      </span>
+    </div>
+
+    <!-- Minical -->
+    <div class="pt-4">
+      <div class="flex h-12 items-center justify-between px-4 pb-4">
+        <h2 class="rc-heading text-2xl font-bold">
+          August <span class="font-normal text-(--highlight)">2026</span>
+        </h2>
+        <div class="flex items-center gap-1">
+          <span class="rc-circle flex size-7 items-center justify-center">
+            <svg
+              viewBox="0 0 24 24"
+              class="size-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="m6 15 6-6 6 6" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </span>
+          <span class="rc-circle flex size-7 items-center justify-center">
+            <svg
+              viewBox="0 0 24 24"
+              class="size-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </span>
+        </div>
+      </div>
+
+      <div class="px-3">
+        <div class="flex">
+          {
+            weekdayLabels.map((label, i) => (
+              <div
+                class:list={[
+                  "rc-numerical flex-1 text-center text-[11px] text-(--muted)",
+                  i >= 5 && "bg-(--weekend)",
+                  i === 4 && "text-(--today)",
+                ]}
+              >
+                {label.toUpperCase()}
+              </div>
+            ))
+          }
+        </div>
+
+        {
+          miniWeeks.map((week, weekIndex) => (
+            <div class:list={["flex", weekIndex === CURRENT_WEEK_INDEX && "bg-(--hover)"]}>
+              {week.map((day, i) => {
+                const isSelected =
+                  !day.outside && day.num === 28 && weekIndex === CURRENT_WEEK_INDEX
+                const dots = !day.outside ? miniDots[day.num] : undefined
+                return (
+                  <div class:list={["flex flex-1 justify-center", i >= 5 && "bg-(--weekend)"]}>
+                    <div
+                      class:list={[
+                        "relative flex size-8 items-center justify-center text-sm",
+                        day.outside && "text-(--muted)",
+                        isSelected &&
+                          "rc-circle bg-(--today) font-bold text-(--primary-foreground)",
+                      ]}
+                    >
+                      {day.num}
+                      {dots && !isSelected && (
+                        <span class="absolute bottom-0.5 left-1/2 flex -translate-x-1/2 gap-[3px]">
+                          {dots.map((color) => (
+                            <span class="rc-circle size-1" style={`background: ${color}`} />
+                          ))}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ))
+        }
+      </div>
+    </div>
+
+    <!-- Agenda -->
+    <div class="mt-3 flex min-h-0 grow flex-col overflow-hidden">
+      {
+        agenda.map((section) => (
+          <div class="border-b border-(--divider)">
+            <div class="flex h-8 items-center gap-2 px-3 py-1.5 text-sm">
+              <span
+                class:list={["rc-numerical font-bold uppercase", section.today && "text-(--today)"]}
+              >
+                {section.label}
+              </span>
+              <span
+                class:list={["rc-numerical", section.today ? "text-(--today)" : "text-(--muted)"]}
+              >
+                {section.date}
+              </span>
+            </div>
+
+            <div class="flex flex-col gap-1 pb-2">
+              {!section.allDay?.length && !section.rows.length && (
+                <div class="px-3 py-1 text-sm text-(--muted)">No events</div>
+              )}
+
+              {section.allDay && section.allDay.length > 0 && (
+                <div class="flex flex-wrap gap-1 px-3 py-1">
+                  {section.allDay.map((chip) => (
+                    <span
+                      class="rc-ev rc-allday px-1.5 text-xs leading-5"
+                      style={chip.color ? `--ev: ${chip.color}` : undefined}
+                    >
+                      {chip.title}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {section.rows.map((row) => (
+                <div
+                  class="rc-ev flex gap-3 py-1 pr-2 pl-3.5"
+                  style={row.color ? `--ev: ${row.color}` : undefined}
+                >
+                  <div class="w-[3px] shrink-0 rounded-[2px] bg-(--ev)" />
+                  <div class="text-sm">
+                    <div class="rc-numerical h-4 text-xs text-(--muted)">{row.time}</div>
+                    <div class="font-medium">{row.title}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+
+  <!-- Main -->
+  <div class="flex min-w-0 grow flex-col">
+    <!-- Header -->
+    <div class="flex shrink-0 items-center gap-2 p-4">
+      <span class="rc-btn">Today</span>
+      <span class="rc-btn rc-btn--icon">
+        <svg viewBox="0 0 24 24" class="size-4" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="3"></circle>
+          <path
+            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"
+          ></path>
+        </svg>
+      </span>
+      <div class="grow"></div>
+      <span class="rc-btn min-w-24 justify-between">
+        Month
+        <svg
+          viewBox="0 0 24 24"
+          class="size-4 text-(--muted)"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path d="m6 9 6 6 6-6" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </span>
+      <span class="rc-btn rc-btn--icon">
+        <svg viewBox="0 0 24 24" class="size-4" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="11" cy="11" r="7"></circle>
+          <path d="m21 21-4.35-4.35" stroke-linecap="round"></path>
+        </svg>
+      </span>
+    </div>
+
+    <!-- Weekday labels -->
+    <div class="grid grid-cols-7 border-b border-(--divider)">
+      {
+        weekdayLabels.map((label, i) => (
+          <div
+            class:list={[
+              "rc-numerical py-2 text-center text-[11px] font-medium text-(--muted) uppercase",
+              i >= 5 && "bg-(--weekend)",
+            ]}
+          >
+            {label}
+          </div>
+        ))
+      }
+    </div>
+
+    <!-- Month grid -->
+    <div class="flex min-h-0 grow flex-col">
+      {
+        weeks.map((week) => (
+          <div class="flex min-h-0 grow basis-0 flex-col border-b border-(--divider) last:border-b-0">
+            <div class="relative grid shrink-0 grid-cols-7">
+              {week.days.map((day) => (
+                <div
+                  class:list={[
+                    "rc-numerical flex min-w-0 items-center justify-end gap-1 overflow-hidden border-r border-(--divider) p-1 last:border-r-0",
+                    day.weekend && "bg-(--weekend)",
+                    day.active && "bg-(--accent)",
+                  ]}
+                >
+                  {day.monthLabel && (
+                    <span class="truncate text-xs text-(--muted)">{day.monthLabel}</span>
+                  )}
+                  <span
+                    class:list={[
+                      "flex h-5 w-5 items-center justify-center text-xs",
+                      day.today && "rc-circle bg-(--today) text-(--primary-foreground)",
+                    ]}
+                  >
+                    {day.num}
+                  </span>
+                </div>
+              ))}
+              {week.boundaryCol != null && (
+                <div
+                  class="absolute top-0 bottom-0 z-10 w-0.5 -translate-x-px bg-(--month-boundary)"
+                  style={`left: ${((week.boundaryCol / 7) * 100).toFixed(4)}%`}
+                />
+              )}
+            </div>
+
+            <div class="relative grid min-h-0 grow grid-cols-7">
+              {week.bars?.map((bar) => (
+                <div
+                  class="rc-ev rc-allday absolute top-0 z-10 h-[17px] truncate px-1 py-px text-xs leading-4"
+                  style={barStyle(bar)}
+                >
+                  {bar.title}
+                </div>
+              ))}
+
+              {week.days.map((day) => (
+                <div
+                  class:list={[
+                    "flex min-h-0 flex-col gap-1 overflow-hidden border-r border-(--divider) px-1 pb-1 last:border-r-0",
+                    day.weekend && "bg-(--weekend)",
+                    day.active && "bg-(--accent)",
+                  ]}
+                >
+                  {day.spacer && <div class="h-[17px] shrink-0" />}
+                  {day.chips?.map((chip) => (
+                    <div
+                      class="rc-ev flex shrink-0 items-center gap-1 truncate text-xs"
+                      style={chip.color ? `--ev: ${chip.color}` : undefined}
+                    >
+                      <div class="h-full w-0.5 shrink-0 bg-(--ev)" />
+                      <span class="truncate">
+                        <span class="rc-numerical rc-ev-text text-[10px]">{chip.time}</span>{" "}
+                        {chip.title}
+                      </span>
+                    </div>
+                  ))}
+                  {day.more && (
+                    <div class="shrink-0 truncate px-0.5 text-xs text-(--muted)">
+                      +{day.more} more
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              {week.boundaryCol != null && (
+                <div
+                  class="absolute top-0 bottom-0 z-10 w-0.5 -translate-x-px bg-(--month-boundary)"
+                  style={`left: ${((week.boundaryCol / 7) * 100).toFixed(4)}%`}
+                />
+              )}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</div>

--- a/website/src/content/docs/docs/themes.md
+++ b/website/src/content/docs/docs/themes.md
@@ -5,6 +5,8 @@ description: Customize how renCal looks
 
 Change renCal's theme from the settings, or press <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>T</kbd> to cycle through them.
 
+You can preview all built-in themes (and design your own) in the [theme playground](/themes).
+
 | Theme: Gruvbox                                                                                                                         | Theme: Catpuccin Light                                                                                                                                 | Theme: Hackerman                                                                                                                           |
 | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | <img src="/docs/theme-gruvbox.png" alt="Gruvbox theme" style="height: 18rem; width: 100%; object-fit: cover; object-position: top;" /> | <img src="/docs/theme-catpuccin-light.png" alt="Catpuccin Light theme" style="height: 18rem; width: 100%; object-fit: cover; object-position: top;" /> | <img src="/docs/theme-hackerman.png" alt="Hackerman theme" style="height: 18rem; width: 100%; object-fit: cover; object-position: top;" /> |

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -121,7 +121,7 @@ const segControls = [
 >
   <section class="mx-auto flex w-full flex-col gap-10 px-6 pt-6 md:px-10">
     <div class="flex flex-col gap-3">
-      <h1 class="text-3xl">Themes</h1>
+      <h1 class="text-3xl hidden">renCal Themes</h1>
       <p>
         Discover themes for renCal or create your own. Copy the generated CSS file into
         <code class="text-sm">~/.config/rencal/themes/</code> to use it.
@@ -272,27 +272,30 @@ const segControls = [
         <div class="flex flex-col gap-3">
           <div class="flex items-center justify-between">
             <h2 class="text-lg">Theme CSS</h2>
+          </div>
+          <pre class="tp-code"><code id="tp-css-code" /></pre>
+
+          <div class="flex gap-2">
             <button
               type="button"
               id="tp-copy"
               data-copy-command=""
               aria-label="Copy theme CSS"
-              class="flex items-center gap-2! text-sm"
+              class="flex flex-1 items-center justify-center gap-2! text-sm"
             >
               Copy
               <span data-icon-copy><CopyIcon class="h-4 w-4" /></span>
               <span data-icon-check hidden><CheckIcon class="h-4 w-4" /></span>
             </button>
+            <button
+              type="button"
+              id="tp-download"
+              class="primary flex flex-1 items-center justify-center gap-2!"
+            >
+              <DownloadIcon class="h-4 w-4" />
+              Download
+            </button>
           </div>
-          <pre class="tp-code"><code id="tp-css-code" /></pre>
-          <button
-            type="button"
-            id="tp-download"
-            class="primary flex w-full items-center justify-center gap-2!"
-          >
-            <DownloadIcon class="h-4 w-4" />
-            Download
-          </button>
           <p class="text-sm opacity-80">
             If you create a theme that you want to share, you can 
             <a href="https://github.com/t4t5/rencal/pulls" class="text-primary hover:underline">open a PR</a>!

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -1,0 +1,501 @@
+---
+import "../styles/index.css"
+import "../styles/themes.css"
+
+import BaseLayout from "../layouts/BaseLayout.astro"
+import AppPreview from "../components/themes/AppPreview.astro"
+import CheckIcon from "../icons/check.astro"
+import CopyIcon from "../icons/copy.astro"
+import { site } from "../site"
+
+// The built-in theme files live in the app source, one directory up from the
+// website project. Inlining them at build time keeps this page in sync with
+// the app automatically. Mirrors src/themes/manifest.ts (minus "omarchy",
+// whose palette is derived from the OS theme at runtime).
+const themeFiles = import.meta.glob<string>("../../../src/themes/*.css", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+})
+
+function parseThemeCss(css: string): Record<string, string> {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "")
+  const vars: Record<string, string> = {}
+  for (const match of withoutComments.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    vars[match[1]] = match[2].trim()
+  }
+  return vars
+}
+
+// Ren's color primitives live in the app's global.css `:root` block (ren.css
+// itself is comment-only), so they're spelled out here. Keep in sync with the
+// app's global.css.
+const REN_CORE: Record<string, string> = {
+  "--background": "#131313",
+  "--foreground": "white",
+  "--muted": "rgba(255, 255, 255, 0.5)",
+  "--primary": "#f56313",
+  "--highlight": "#ff610b",
+  "--today": "#3a93ff",
+  "--hover-tint": "white",
+  "--hover-mix": "5%",
+}
+
+const themes = [
+  { id: "ren", name: "Ren" },
+  { id: "catpuccin-latte", name: "Catpuccin Latte" },
+  { id: "tokyonight", name: "Tokyo Night" },
+  { id: "classic", name: "Classic" },
+  { id: "nord", name: "Nord" },
+].map((theme) => {
+  const css = themeFiles[`../../../src/themes/${theme.id}.css`]
+  if (css === undefined) throw new Error(`Missing theme file for "${theme.id}"`)
+  return { ...theme, vars: { ...(theme.id === "ren" ? REN_CORE : {}), ...parseThemeCss(css) } }
+})
+
+// The full ren defaults (also declared on `.rc-scope` in themes.css). Used to
+// fill editor fields for primitives a theme doesn't override.
+const REN_DEFAULTS: Record<string, string> = {
+  ...REN_CORE,
+  "--radius-base": "0px",
+  "--radius-circle": "0px",
+  "--font-heading": "var(--mono)",
+  "--font-button": "var(--mono)",
+  "--font-numerical": "var(--mono)",
+  "--font-heading-transform": "uppercase",
+  "--font-button-transform": "uppercase",
+  "--font-numerical-transform": "uppercase",
+}
+
+const payload = { themes, defaults: REN_DEFAULTS }
+
+const styleAttr = (vars: Record<string, string>) =>
+  Object.entries(vars)
+    .map(([name, value]) => `${name}: ${value}`)
+    .join("; ")
+
+const renVars = themes[0].vars
+
+const colorControls = [
+  { var: "--background", label: "Background" },
+  { var: "--foreground", label: "Text" },
+  { var: "--muted", label: "Muted text" },
+  { var: "--primary", label: "Primary" },
+  { var: "--highlight", label: "Highlight" },
+  { var: "--today", label: "Today" },
+  { var: "--hover-tint", label: "Hover tint" },
+]
+
+const segControls = [
+  {
+    seg: "font",
+    label: "Font",
+    options: [
+      { value: "mono", label: "Mono" },
+      { value: "sans", label: "Sans" },
+    ],
+  },
+  {
+    seg: "caps",
+    label: "Headings",
+    options: [
+      { value: "uppercase", label: "Caps" },
+      { value: "normal", label: "Normal" },
+    ],
+  },
+  {
+    seg: "circle",
+    label: "Circles",
+    options: [
+      { value: "sharp", label: "Off" },
+      { value: "pill", label: "On" },
+    ],
+  },
+]
+---
+
+<BaseLayout
+  title={`Themes - ${site.title}`}
+  description={`Preview ${site.title}'s built-in themes or design your own.`}
+>
+  <section class="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 pt-6 md:px-10">
+    <div class="flex max-w-2xl flex-col gap-3">
+      <h1 class="text-3xl">Themes</h1>
+      <p>
+        Discover or create your own themes for renCal.
+      </p>
+      <p>
+        Copy the generated CSS file into
+        <code class="text-sm">~/.config/rencal/themes/</code> and renCal picks it up live.
+      </p>
+    </div>
+
+    <div class="grid items-start gap-10 lg:grid-cols-[320px_minmax(0,1fr)]">
+      <!-- Preview (first on mobile, right column on desktop) -->
+      <div class="order-1 flex flex-col gap-3 lg:sticky lg:top-6 lg:order-2">
+        <AppPreview />
+      </div>
+
+      <!-- Controls -->
+      <aside class="order-2 flex flex-col gap-10 lg:order-1">
+        <div class="flex flex-col gap-3">
+          <div class="grid grid-cols-2 gap-2">
+            {
+              themes.map((theme) => (
+                <button type="button" class="tp-tile" data-theme-tile={theme.id}>
+                  <div class="rc-scope w-full" style={styleAttr(theme.vars)}>
+                    <div class="flex h-16 w-full flex-col gap-2 rounded-[4px] border border-white/10 bg-(--background) p-2">
+                      <div class="flex items-center justify-between gap-2">
+                        <div class="h-[4px] grow rounded bg-(--foreground)" />
+                        <div class="rc-circle size-3 bg-(--primary)" />
+                      </div>
+                      <div class="relative grow">
+                        <div class="absolute inset-0 flex justify-between gap-1.5">
+                          <div class="grow bg-(--hover-tint) opacity-5" />
+                          <div class="grow bg-(--hover-tint) opacity-5" />
+                          <div class="grow bg-(--hover-tint) opacity-10" />
+                        </div>
+                        <div class="absolute inset-0 flex flex-col">
+                          <div class="grow" />
+                          <div class="grow bg-(--hover-tint) opacity-5" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <span class="text-xs text-muted">{theme.name}</span>
+                </button>
+              ))
+            }
+
+            <button type="button" class="tp-tile" data-theme-tile="custom">
+              <div id="tp-custom-palette" class="rc-scope w-full" style={styleAttr(renVars)}>
+                <div
+                  class="flex h-16 w-full flex-col gap-2 rounded-[4px] border border-dashed border-white/20 bg-(--background) p-2"
+                >
+                  <div class="flex items-center justify-between gap-2">
+                    <div class="h-[4px] grow rounded bg-(--foreground)"></div>
+                    <div class="rc-circle size-3 bg-(--primary)"></div>
+                  </div>
+                  <div class="relative grow">
+                    <div class="absolute inset-0 flex justify-between gap-1.5">
+                      <div class="grow bg-(--hover-tint) opacity-5"></div>
+                      <div class="grow bg-(--hover-tint) opacity-5"></div>
+                      <div class="grow bg-(--hover-tint) opacity-10"></div>
+                    </div>
+                    <div class="absolute inset-0 flex flex-col">
+                      <div class="grow"></div>
+                      <div class="grow bg-(--hover-tint) opacity-5"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <span class="text-xs text-muted">Custom</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-5">
+          <h2 class="text-lg">Customize</h2>
+
+          <div class="flex flex-col gap-3">
+            {
+              colorControls.map((control) => (
+                <div class="flex items-center gap-3">
+                  <input
+                    type="color"
+                    class="tp-swatch"
+                    data-color-for={control.var}
+                    aria-label={`${control.label} color`}
+                  />
+                  <div class="flex min-w-0 grow flex-col gap-0.5">
+                    <label class="text-xs tracking-wide text-muted uppercase">
+                      {control.label}
+                    </label>
+                    <input
+                      type="text"
+                      class="tp-text"
+                      data-text-for={control.var}
+                      spellcheck="false"
+                      autocomplete="off"
+                      aria-label={`${control.label} value`}
+                    />
+                  </div>
+                </div>
+              ))
+            }
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <div class="flex justify-between text-xs">
+              <label class="tracking-wide text-muted uppercase">Hover strength</label>
+              <span class="text-muted" data-range-out="--hover-mix"></span>
+            </div>
+            <input
+              type="range"
+              class="tp-range"
+              min="0"
+              max="25"
+              step="1"
+              data-range-for="--hover-mix"
+            />
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <div class="flex justify-between text-xs">
+              <label class="tracking-wide text-muted uppercase">Button radius</label>
+              <span class="text-muted" data-range-out="--radius-base"></span>
+            </div>
+            <input
+              type="range"
+              class="tp-range"
+              min="0"
+              max="1"
+              step="0.05"
+              data-range-for="--radius-base"
+            />
+          </div>
+
+          {
+            segControls.map((control) => (
+              <div class="flex items-center justify-between gap-3">
+                <span class="text-xs tracking-wide text-muted uppercase">{control.label}</span>
+                <div class="tp-seg" data-seg={control.seg}>
+                  {control.options.map((option) => (
+                    <button type="button" data-seg-value={option.value}>
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))
+          }
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <h2 class="text-lg">Theme CSS</h2>
+            <button
+              type="button"
+              id="tp-copy"
+              data-copy-command=""
+              aria-label="Copy theme CSS"
+              class="flex items-center gap-2! text-sm"
+            >
+              Copy
+              <span data-icon-copy><CopyIcon class="h-4 w-4" /></span>
+              <span data-icon-check hidden><CheckIcon class="h-4 w-4" /></span>
+            </button>
+          </div>
+          <pre class="tp-code"><code id="tp-css-code" /></pre>
+          <p class="text-sm opacity-80">
+            Save it as <code>~/.config/rencal/themes/my-theme.css</code> — renCal watches that folder
+            and applies changes live.
+            <a href="/docs/themes" class="text-primary hover:underline">Learn more</a>
+          </p>
+        </div>
+      </aside>
+    </div>
+  </section>
+</BaseLayout>
+
+<script
+  type="application/json"
+  id="tp-data"
+  set:html={JSON.stringify(payload).replace(/</g, "\\u003c")}
+/>
+
+<script src="../lib/copy-button.js"></script>
+
+<script>
+  type Vars = Record<string, string>
+
+  const data = JSON.parse(document.getElementById("tp-data")!.textContent!) as {
+    themes: { id: string; name: string; vars: Vars }[]
+    defaults: Vars
+  }
+
+  const preview = document.getElementById("rc-preview") as HTMLElement
+  const customPalette = document.getElementById("tp-custom-palette") as HTMLElement
+  const cssOut = document.getElementById("tp-css-code") as HTMLElement
+  const copyButton = document.getElementById("tp-copy") as HTMLElement
+  const tiles = [...document.querySelectorAll<HTMLElement>("[data-theme-tile]")]
+
+  // Hidden probe inside the preview: resolves any CSS color (including
+  // var() references against the active theme) to a computed rgb value.
+  const probe = document.createElement("span")
+  probe.style.display = "none"
+  preview.appendChild(probe)
+
+  const STORAGE_KEY = "rencal-theme-playground-v1"
+
+  let active = "ren"
+  let customVars: Vars = { ...data.themes[0].vars }
+
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "")
+    if (saved && typeof saved === "object") {
+      if (saved.customVars && typeof saved.customVars === "object") {
+        customVars = saved.customVars
+      }
+      const validIds = [...data.themes.map((t) => t.id), "custom"]
+      if (validIds.includes(saved.active)) active = saved.active
+    }
+  } catch {
+    // No saved state (or unreadable storage) — start from the defaults.
+  }
+
+  // Deep link: /themes#tokyonight selects that theme (wins over saved state).
+  const hashId = decodeURIComponent(location.hash.slice(1))
+  if ([...data.themes.map((theme) => theme.id), "custom"].includes(hashId)) active = hashId
+
+  const themeById = (id: string) => data.themes.find((theme) => theme.id === id)
+  const currentVars = (): Vars =>
+    active === "custom" ? customVars : (themeById(active)?.vars ?? {})
+  const effective = (name: string): string => currentVars()[name] ?? data.defaults[name] ?? ""
+
+  function applyVars(el: HTMLElement, vars: Vars) {
+    const stale: string[] = []
+    for (let i = 0; i < el.style.length; i++) {
+      const prop = el.style[i]
+      if (prop.startsWith("--")) stale.push(prop)
+    }
+    for (const prop of stale) el.style.removeProperty(prop)
+    for (const [name, value] of Object.entries(vars)) el.style.setProperty(name, value)
+  }
+
+  function resolveToHex(value: string): string {
+    probe.style.color = ""
+    probe.style.color = value
+    const rgb = getComputedStyle(probe).color
+    const match = rgb.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/)
+    if (!match) return "#000000"
+    return (
+      "#" +
+      [match[1], match[2], match[3]]
+        .map((channel) => Math.round(Number(channel)).toString(16).padStart(2, "0"))
+        .join("")
+    )
+  }
+
+  function becomeCustom() {
+    if (active === "custom") return
+    customVars = { ...currentVars() }
+    active = "custom"
+  }
+
+  function setVars(updates: Vars) {
+    becomeCustom()
+    Object.assign(customVars, updates)
+    render()
+  }
+
+  function syncEditor() {
+    // Order matters: applyVars() must have run so the probe resolves var()
+    // references (e.g. Catpuccin's --theme-base) against the active theme.
+    for (const input of document.querySelectorAll<HTMLInputElement>("[data-text-for]")) {
+      input.value = effective(input.dataset.textFor!)
+    }
+    for (const input of document.querySelectorAll<HTMLInputElement>("[data-color-for]")) {
+      input.value = resolveToHex(effective(input.dataset.colorFor!))
+    }
+
+    for (const input of document.querySelectorAll<HTMLInputElement>("[data-range-for]")) {
+      const name = input.dataset.rangeFor!
+      const value = Number.parseFloat(effective(name)) || 0
+      input.value = String(value)
+      const out = document.querySelector(`[data-range-out="${name}"]`)
+      if (out) out.textContent = name === "--hover-mix" ? `${value}%` : `${value}rem`
+    }
+
+    const segState: Record<string, string> = {
+      font: effective("--font-heading").includes("mono") ? "mono" : "sans",
+      caps: effective("--font-heading-transform") === "uppercase" ? "uppercase" : "normal",
+      circle: Number.parseFloat(effective("--radius-circle")) === 0 ? "sharp" : "pill",
+    }
+    for (const seg of document.querySelectorAll<HTMLElement>("[data-seg]")) {
+      for (const button of seg.querySelectorAll("button")) {
+        button.setAttribute(
+          "aria-pressed",
+          String(button.dataset.segValue === segState[seg.dataset.seg!]),
+        )
+      }
+    }
+  }
+
+  function syncCss() {
+    const name = active === "custom" ? "My Theme" : (themeById(active)?.name ?? "My Theme")
+    const lines = [`/* @name ${name} */`]
+    for (const [varName, value] of Object.entries(currentVars())) {
+      lines.push(`${varName}: ${value};`)
+    }
+    const css = lines.join("\n")
+    cssOut.textContent = css
+    copyButton.setAttribute("data-copy-command", css)
+  }
+
+  function render() {
+    applyVars(preview, currentVars())
+    applyVars(customPalette, customVars)
+    for (const tile of tiles) {
+      tile.classList.toggle("is-active", tile.dataset.themeTile === active)
+    }
+    syncEditor()
+    syncCss()
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ active, customVars }))
+    } catch {
+      // Storage unavailable — the playground still works, it just won't persist.
+    }
+  }
+
+  for (const tile of tiles) {
+    tile.addEventListener("click", () => {
+      active = tile.dataset.themeTile!
+      history.replaceState(null, "", `#${active}`)
+      render()
+    })
+  }
+
+  for (const input of document.querySelectorAll<HTMLInputElement>("[data-text-for]")) {
+    input.addEventListener("change", () => {
+      setVars({ [input.dataset.textFor!]: input.value.trim() })
+    })
+  }
+
+  for (const input of document.querySelectorAll<HTMLInputElement>("[data-color-for]")) {
+    input.addEventListener("input", () => {
+      setVars({ [input.dataset.colorFor!]: input.value })
+    })
+  }
+
+  for (const input of document.querySelectorAll<HTMLInputElement>("[data-range-for]")) {
+    input.addEventListener("input", () => {
+      const name = input.dataset.rangeFor!
+      setVars({ [name]: name === "--hover-mix" ? `${input.value}%` : `${input.value}rem` })
+    })
+  }
+
+  for (const seg of document.querySelectorAll<HTMLElement>("[data-seg]")) {
+    seg.addEventListener("click", (event) => {
+      const button = (event.target as HTMLElement).closest<HTMLElement>("[data-seg-value]")
+      if (!button) return
+      const value = button.dataset.segValue!
+
+      if (seg.dataset.seg === "font") {
+        const font = value === "mono" ? "var(--mono)" : "var(--sans)"
+        setVars({ "--font-heading": font, "--font-button": font, "--font-numerical": font })
+      } else if (seg.dataset.seg === "caps") {
+        const transform = value === "uppercase" ? "uppercase" : "none"
+        setVars({
+          "--font-heading-transform": transform,
+          "--font-button-transform": transform,
+          "--font-numerical-transform": transform,
+        })
+      } else if (seg.dataset.seg === "circle") {
+        setVars({ "--radius-circle": value === "pill" ? "calc(infinity * 1px)" : "0px" })
+      }
+    })
+  }
+
+  render()
+</script>

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -6,6 +6,7 @@ import BaseLayout from "../layouts/BaseLayout.astro"
 import AppPreview from "../components/themes/AppPreview.astro"
 import CheckIcon from "../icons/check.astro"
 import CopyIcon from "../icons/copy.astro"
+import DownloadIcon from "../icons/download.astro"
 import { site } from "../site"
 
 // The built-in theme files live in the app source, one directory up from the
@@ -119,14 +120,11 @@ const segControls = [
   description={`Preview ${site.title}'s built-in themes or design your own.`}
 >
   <section class="mx-auto flex w-full flex-col gap-10 px-6 pt-6 md:px-10">
-    <div class="flex max-w-2xl flex-col gap-3">
+    <div class="flex flex-col gap-3">
       <h1 class="text-3xl">Themes</h1>
       <p>
-        Discover or create your own themes for renCal.
-      </p>
-      <p>
-        Copy the generated CSS file into
-        <code class="text-sm">~/.config/rencal/themes/</code> and renCal picks it up live.
+        Discover themes for renCal or create your own. Copy the generated CSS file into
+        <code class="text-sm">~/.config/rencal/themes/</code> to use it.
       </p>
     </div>
 
@@ -287,10 +285,17 @@ const segControls = [
             </button>
           </div>
           <pre class="tp-code"><code id="tp-css-code" /></pre>
+          <button
+            type="button"
+            id="tp-download"
+            class="primary flex w-full items-center justify-center gap-2!"
+          >
+            <DownloadIcon class="h-4 w-4" />
+            Download
+          </button>
           <p class="text-sm opacity-80">
-            Save it as <code>~/.config/rencal/themes/my-theme.css</code> — renCal watches that folder
-            and applies changes live.
-            <a href="/docs/themes" class="text-primary hover:underline">Learn more</a>
+            If you create a theme that you want to share, you can 
+            <a href="https://github.com/t4t5/rencal/pulls" class="text-primary hover:underline">open a PR</a>!
           </p>
         </div>
       </aside>
@@ -318,6 +323,7 @@ const segControls = [
   const customPalette = document.getElementById("tp-custom-palette") as HTMLElement
   const cssOut = document.getElementById("tp-css-code") as HTMLElement
   const copyButton = document.getElementById("tp-copy") as HTMLElement
+  const downloadButton = document.getElementById("tp-download") as HTMLButtonElement
   const tiles = [...document.querySelectorAll<HTMLElement>("[data-theme-tile]")]
 
   // Hidden probe inside the preview: resolves any CSS color (including
@@ -455,6 +461,16 @@ const segControls = [
       render()
     })
   }
+
+  downloadButton.addEventListener("click", () => {
+    const blob = new Blob([cssOut.textContent ?? ""], { type: "text/css" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `${active === "custom" ? "my-theme" : active}.css`
+    link.click()
+    URL.revokeObjectURL(url)
+  })
 
   for (const input of document.querySelectorAll<HTMLInputElement>("[data-text-for]")) {
     input.addEventListener("change", () => {

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -118,7 +118,7 @@ const segControls = [
   title={`Themes - ${site.title}`}
   description={`Preview ${site.title}'s built-in themes or design your own.`}
 >
-  <section class="mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 pt-6 md:px-10">
+  <section class="mx-auto flex w-full flex-col gap-10 px-6 pt-6 md:px-10">
     <div class="flex max-w-2xl flex-col gap-3">
       <h1 class="text-3xl">Themes</h1>
       <p>

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -123,8 +123,7 @@ const segControls = [
     <div class="flex flex-col gap-3">
       <h1 class="text-3xl hidden">renCal Themes</h1>
       <p>
-        Discover themes for renCal or create your own. Copy the generated CSS file into
-        <code class="text-sm">~/.config/rencal/themes/</code> to use it.
+        Build your own renCal theme by adjusting the colors and styles below. Place the generated CSS file in <code class="text-sm">~/.config/rencal/themes/</code> to use it.
       </p>
     </div>
 
@@ -297,8 +296,8 @@ const segControls = [
             </button>
           </div>
           <p class="text-sm opacity-80">
-            If you create a theme that you want to share, you can 
-            <a href="https://github.com/t4t5/rencal/pulls" class="text-primary hover:underline">open a PR</a>!
+            If you want to share your theme with others, you can
+            <a href="https://github.com/t4t5/rencal/pulls" class="text-primary hover:underline">open a PR</a>.
           </p>
         </div>
       </aside>

--- a/website/src/styles/themes.css
+++ b/website/src/styles/themes.css
@@ -1,0 +1,236 @@
+/* Styles for the /themes playground page.
+ *
+ * The `.rc-scope` block mirrors renCal's theme system: the ren defaults from
+ * the app's src/global.css `:root` block, plus the derived-token chain from
+ * its `body` block. Theme primitives are applied as inline styles on top of
+ * this scope (the website equivalent of the app's `[data-theme]` wrapping),
+ * so the derivations react to them exactly like in the app.
+ * Keep the values in sync with src/global.css.
+ */
+
+.rc-scope {
+  --mono: "Geist Mono", ui-monospace, monospace;
+  --sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  --font-heading: var(--mono);
+  --font-button: var(--mono);
+  --font-numerical: var(--mono);
+
+  --font-heading-transform: uppercase;
+  --font-button-transform: uppercase;
+  --font-numerical-transform: uppercase;
+
+  --radius-base: 0px;
+  --radius-circle: 0px;
+  --control-height: 34px;
+
+  --background: #131313;
+  --foreground: white;
+  --muted: rgba(255, 255, 255, 0.5);
+
+  --primary: #f56313;
+
+  --today: #3a93ff;
+  --highlight: #ff610b;
+
+  --success: #4caf50;
+  --warning: #fd8742;
+  --error: #e25252;
+
+  --hover-tint: white;
+  --hover-mix: 5%;
+  --popover-tint: black;
+  --popover-mix: 4%;
+
+  /* Derived tokens — same formulas as the app's global.css `body` block */
+  --hover: color-mix(in srgb, var(--hover-tint) var(--hover-mix), transparent);
+  --secondary: var(--hover);
+  --secondary-hover: color-mix(in srgb, var(--hover-tint) var(--hover-mix), var(--secondary));
+  --accent: color-mix(in srgb, var(--hover-tint) var(--hover-mix), var(--secondary-hover));
+  --weekend: var(--hover);
+  --divider: color-mix(in srgb, var(--hover-tint) var(--hover-mix), var(--secondary-hover));
+  --card: color-mix(in srgb, var(--hover-tint) var(--hover-mix), var(--background));
+  --input: color-mix(in srgb, var(--hover-tint) var(--hover-mix), var(--divider));
+  --primary-hover: color-mix(in srgb, white var(--hover-mix), var(--primary));
+  --primary-foreground: var(--background);
+  --popover: color-mix(in srgb, var(--popover-tint) var(--popover-mix), var(--background));
+
+  --month-boundary: color-mix(in srgb, var(--foreground) 28%, var(--background));
+
+  /* Radius steps (app: Tailwind radius scale derived from --radius-base) */
+  --radius-md: max(0px, calc(var(--radius-base) - 2px));
+  --radius-ev: max(0px, calc(var(--radius-base) - 6px));
+
+  font-family: var(--sans);
+}
+
+/* App typography utilities (see the @utility blocks in the app's global.css) */
+.rc-heading {
+  font-family: var(--font-heading);
+  text-transform: var(--font-heading-transform, none);
+}
+
+.rc-numerical {
+  font-family: var(--font-numerical);
+  text-transform: var(--font-numerical-transform, none);
+}
+
+/* Simplified static version of the app's Button (secondary variant) */
+.rc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: var(--control-height);
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  font-family: var(--font-button);
+  text-transform: var(--font-button-transform, none);
+  background: var(--secondary);
+  color: var(--foreground);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 0 0 1px var(--border-button, transparent);
+}
+
+.rc-btn--icon {
+  width: var(--control-height);
+  padding: 0;
+}
+
+.rc-btn--ghost {
+  background: transparent;
+  box-shadow: none;
+}
+
+.rc-circle {
+  border-radius: var(--radius-circle, calc(infinity * 1px));
+}
+
+/* Event colors — same formulas as the app's getEventBlockColors() */
+.rc-ev {
+  --ev: var(--primary);
+  --ev-boost: oklch(from var(--ev) l calc(c * 1.4) h);
+}
+
+.rc-ev-text {
+  color: color-mix(in srgb, var(--ev-boost) 40%, var(--foreground));
+}
+
+.rc-allday {
+  background: color-mix(in srgb, var(--ev-boost) 20%, var(--background));
+  color: color-mix(in srgb, var(--ev-boost) 40%, var(--foreground));
+  border-radius: var(--radius-ev);
+}
+
+/* ---------------------------------------------------------------------------
+ * Playground chrome (theme tiles, editor controls) — uses the website's own
+ * design tokens, not the preview scope.
+ * ------------------------------------------------------------------------ */
+
+.tp-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  border: 2px solid transparent;
+  border-radius: 10px;
+  padding: 6px;
+  background: transparent;
+  text-transform: none;
+}
+
+.tp-tile:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.tp-tile.is-active {
+  border-color: var(--primary);
+}
+
+.tp-swatch {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  padding: 2px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.tp-swatch::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.tp-swatch::-webkit-color-swatch {
+  border: none;
+  border-radius: 5px;
+}
+
+.tp-swatch::-moz-color-swatch {
+  border: none;
+  border-radius: 5px;
+}
+
+.tp-text {
+  width: 100%;
+  min-width: 0;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--foreground);
+}
+
+.tp-text:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.tp-range {
+  accent-color: var(--primary);
+  width: 100%;
+}
+
+.tp-seg {
+  display: inline-flex;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.tp-seg button {
+  background: transparent;
+  padding: 4px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: none;
+}
+
+.tp-seg button + button {
+  border-left: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.tp-seg button[aria-pressed="true"] {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--foreground);
+}
+
+.tp-code {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  overflow: auto;
+  max-height: 20rem;
+  white-space: pre;
+}

--- a/website/src/styles/themes.css
+++ b/website/src/styles/themes.css
@@ -231,6 +231,12 @@
   font-size: 12px;
   line-height: 1.6;
   overflow: auto;
+  scrollbar-color: transparent transparent;
   max-height: 20rem;
   white-space: pre;
+}
+
+.tp-code::-webkit-scrollbar,
+.tp-code::-webkit-scrollbar-thumb {
+  background: transparent;
 }


### PR DESCRIPTION
Make it easier for users to create their own custom themes with an interactive page on the website.

Closes #55

<img width="2828" height="1664" alt="image" src="https://github.com/user-attachments/assets/0f28433d-3c2d-4461-bb64-ddca16fb6487" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Themes playground with previews of built-in themes.
  * Added customization controls for colors, typography, spacing, corner radius, and calendar styling.
  * Added generated CSS output with copy and download options.
  * Added persistent custom themes and direct theme-selection links.
  * Added responsive calendar previews and a documentation link to the playground.
* **Improvements**
  * Reordered navigation so Changelog appears before Docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->