### PR TITLE
Fix silent launch failures after upgrading while renCal is running

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,12 +75,16 @@ fn setup_bundled_providers(app: &tauri::App) {
     let _ = BUNDLED_PROVIDERS_DIR.set(providers_dir);
 }
 
-fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
-    if let Some(window) = app.get_webview_window("main") {
-        let _ = window.unminimize();
-        let _ = window.show();
-        let _ = window.set_focus();
-    }
+/// Returns whether a main window existed to focus — the single-instance
+/// listener only acks a launch when this is true (see `single_instance`).
+fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    let Some(window) = app.get_webview_window("main") else {
+        return false;
+    };
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+    true
 }
 
 fn spawn_reminder_loop_if_needed(app: &tauri::App) {
@@ -119,7 +123,7 @@ pub async fn run() {
     #[cfg(target_os = "linux")]
     let mut instance_guard = match single_instance::try_acquire_or_signal() {
         Some(g) => g,
-        None => return, // existing instance was signaled to focus; we exit.
+        None => return, // existing instance acked and was focused; we exit.
     };
 
     // Keep the guard on this frame for the whole process; dropping it early
@@ -195,7 +199,7 @@ pub async fn run() {
                         if !urls.is_empty() {
                             deep_links::enqueue_urls(&app_handle, &urls);
                         }
-                        focus_main_window(&app_handle);
+                        focus_main_window(&app_handle)
                     });
                 }
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,8 +75,8 @@ fn setup_bundled_providers(app: &tauri::App) {
     let _ = BUNDLED_PROVIDERS_DIR.set(providers_dir);
 }
 
-/// Returns whether a main window existed to focus — the single-instance
-/// listener only acks a launch when this is true (see `single_instance`).
+/// Returns whether a main window existed to focus; the single-instance
+/// listener acks a launch only when this is true.
 fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     let Some(window) = app.get_webview_window("main") else {
         return false;

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -9,12 +9,10 @@
 //! stream, and waits briefly for a one-byte ack. The primary acks only if its
 //! binary is still on disk (a pacman upgrade unlinks it) and it still has a
 //! main window to show. No ack means the primary is defunct — the new launch
-//! terminates it and takes over the socket, instead of exiting 0 with no
-//! window ever appearing.
+//! takes over the socket, instead of exiting 0 with no window ever appearing.
 
 use std::io::{Read, Write};
 use std::net::Shutdown;
-use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -80,8 +78,9 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
         }
         // No ack: the primary is stale (binary replaced under it), hung, or
         // lost its window. Take over so this launch still produces a window.
+        // The defunct process just lingers without the socket until logout;
+        // killing it isn't worth the machinery (see PR #119 review).
         log::warn!("existing instance did not ack; taking over single-instance role");
-        terminate_defunct_primary(&stream);
     }
 
     // No live instance. Clear any stale file from a prior crash or takeover.
@@ -122,36 +121,6 @@ fn signal_primary(stream: &mut UnixStream) -> std::io::Result<()> {
     stream.read_exact(&mut ack)
 }
 
-/// Best-effort SIGTERM for a primary that failed the handshake, so takeovers
-/// don't leave windowless background processes running (issue #114).
-fn terminate_defunct_primary(stream: &UnixStream) {
-    let mut cred = libc::ucred {
-        pid: 0,
-        uid: 0,
-        gid: 0,
-    };
-    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-    let ret = unsafe {
-        libc::getsockopt(
-            stream.as_raw_fd(),
-            libc::SOL_SOCKET,
-            libc::SO_PEERCRED,
-            (&mut cred as *mut libc::ucred).cast(),
-            &mut len,
-        )
-    };
-    if ret != 0 || cred.pid <= 0 {
-        return;
-    }
-    // Guard against pid reuse: only kill a process that is still rencal.
-    let comm = std::fs::read_to_string(format!("/proc/{}/comm", cred.pid)).unwrap_or_default();
-    if comm.trim_end() != "rencal" {
-        return;
-    }
-    log::warn!("terminating defunct primary instance (pid {})", cred.pid);
-    let _ = unsafe { libc::kill(cred.pid, libc::SIGTERM) };
-}
-
 /// True once the binary this process was launched from has been replaced or
 /// removed (e.g. by a pacman upgrade, which unlinks the old file and leaves
 /// `/proc/self/exe` pointing at "... (deleted)").
@@ -164,7 +133,7 @@ fn exe_is_stale() -> bool {
 /// Spawn a thread that listens for newline-delimited URLs. An empty message
 /// represents a focus-only launch. `on_message` returns whether the launch
 /// was actually handled (a main window exists to show); only then do we ack —
-/// otherwise the connecting process terminates us and takes over as primary.
+/// otherwise the connecting process takes over as primary.
 pub fn spawn_listener<F>(listener: UnixListener, on_message: F)
 where
     F: Fn(Vec<String>) -> bool + Send + 'static,

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -5,13 +5,10 @@
 //! socket; later launches send deep-link URLs to it and exit. Debug and release
 //! use separate sockets so `tauri dev` does not fight the installed app.
 //!
-//! Handshake (issue #114): a later launch writes its URLs, half-closes the
-//! stream, and waits briefly for a one-byte ack. The primary acks only if its
-//! binary is still on disk (a pacman upgrade unlinks it) and it still has a
-//! main window to show. No ack means the primary is defunct — the new launch
-//! takes over the socket, instead of exiting 0 with no window ever appearing.
-//! A primary that finds its own binary replaced exits when yielding, so the
-//! takeover doesn't leave a windowless process running duplicate loops.
+//! Handshake (issue #114): a later launch writes its URLs and waits briefly
+//! for a one-byte ack. The primary acks only if its binary is still on disk
+//! (an upgrade unlinks it) and it has a main window to show; otherwise the
+//! new launch takes over the socket, and a stale primary exits itself.
 
 use std::io::{Read, Write};
 use std::net::Shutdown;
@@ -20,8 +17,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 /// How long each side of the handshake waits on the other. A healthy primary
-/// acks nearly instantly (it only checks its window registry), so this only
-/// delays launches that are about to take over from a defunct primary.
+/// acks nearly instantly, so this only delays takeovers from a defunct one.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 const ACK: &[u8] = b"1";
@@ -78,10 +74,9 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
         if signal_primary(&mut stream).is_ok() {
             return None;
         }
-        // No ack: the primary is stale (binary replaced under it), hung, or
-        // lost its window. Take over so this launch still produces a window.
-        // A stale primary exits itself when yielding (see spawn_listener);
-        // a hung or pre-handshake one lingers until logout.
+        // No ack: the primary is stale, hung, or lost its window. Take over
+        // so this launch still produces a window; a stale primary exits
+        // itself, a hung one lingers until logout.
         log::warn!("existing instance did not ack; taking over single-instance role");
     }
 
@@ -107,8 +102,7 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
 }
 
 /// Send our deep-link URLs (possibly none, meaning focus-only) to the primary
-/// and wait for its ack. Any error means the primary can't be trusted with
-/// this launch and the caller should take over.
+/// and wait for its ack. Any error means the caller should take over.
 fn signal_primary(stream: &mut UnixStream) -> std::io::Result<()> {
     let urls: Vec<String> = std::env::args_os()
         .filter_map(|arg| arg.into_string().ok())
@@ -123,19 +117,17 @@ fn signal_primary(stream: &mut UnixStream) -> std::io::Result<()> {
     stream.read_exact(&mut ack)
 }
 
-/// True once the binary this process was launched from has been replaced or
-/// removed (e.g. by a pacman upgrade, which unlinks the old file and leaves
-/// `/proc/self/exe` pointing at "... (deleted)").
+/// True once the binary we were launched from has been replaced or removed
+/// (an upgrade unlinks it, leaving `/proc/self/exe` at "... (deleted)").
 fn exe_is_stale() -> bool {
     std::fs::read_link("/proc/self/exe")
         .map(|target| target.to_string_lossy().ends_with(" (deleted)"))
         .unwrap_or(false)
 }
 
-/// Spawn a thread that listens for newline-delimited URLs. An empty message
-/// represents a focus-only launch. `on_message` returns whether the launch
-/// was actually handled (a main window exists to show); only then do we ack —
-/// otherwise the connecting process takes over as primary.
+/// Spawn a thread that listens for newline-delimited URLs; an empty message
+/// is a focus-only launch. Ack only when `on_message` returns true (a main
+/// window existed to show) — otherwise the connecting process takes over.
 pub fn spawn_listener<F>(listener: UnixListener, on_message: F)
 where
     F: Fn(Vec<String>) -> bool + Send + 'static,
@@ -149,11 +141,9 @@ where
                 continue;
             }
             if exe_is_stale() {
-                // Our binary was replaced on disk; the connecting launch is
-                // the new version and will take over the socket. Exit
-                // abruptly on purpose: process::exit skips
-                // InstanceGuard::drop, so we don't unlink the socket file
-                // after the successor has already bound it.
+                // The connecting launch will take over the socket.
+                // process::exit deliberately skips InstanceGuard::drop so we
+                // don't unlink the socket file after the successor binds it.
                 log::warn!("binary replaced on disk; exiting so the new launch can take over");
                 std::process::exit(0);
             }

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -4,10 +4,27 @@
 //! panic inside Tauri's tokio runtime. The first process owns a per-user Unix
 //! socket; later launches send deep-link URLs to it and exit. Debug and release
 //! use separate sockets so `tauri dev` does not fight the installed app.
+//!
+//! Handshake (issue #114): a later launch writes its URLs, half-closes the
+//! stream, and waits briefly for a one-byte ack. The primary acks only if its
+//! binary is still on disk (a pacman upgrade unlinks it) and it still has a
+//! main window to show. No ack means the primary is defunct — the new launch
+//! terminates it and takes over the socket, instead of exiting 0 with no
+//! window ever appearing.
 
 use std::io::{Read, Write};
+use std::net::Shutdown;
+use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// How long each side of the handshake waits on the other. A healthy primary
+/// acks nearly instantly (it only checks its window registry), so this only
+/// delays launches that are about to take over from a defunct primary.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+
+const ACK: &[u8] = b"1";
 
 /// Hold for the process lifetime; the kernel removes the socket file when the
 /// listener is dropped (we also unbind explicitly on Drop for cleanliness).
@@ -58,15 +75,16 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
 
     // Existing instance? Forward deep-link arguments (if any), otherwise focus.
     if let Ok(mut stream) = UnixStream::connect(&path) {
-        let urls: Vec<String> = std::env::args_os()
-            .filter_map(|arg| arg.into_string().ok())
-            .filter(|arg| arg.starts_with("rencal:"))
-            .collect();
-        let _ = stream.write_all(urls.join("\n").as_bytes());
-        return None;
+        if signal_primary(&mut stream).is_ok() {
+            return None;
+        }
+        // No ack: the primary is stale (binary replaced under it), hung, or
+        // lost its window. Take over so this launch still produces a window.
+        log::warn!("existing instance did not ack; taking over single-instance role");
+        terminate_defunct_primary(&stream);
     }
 
-    // No live instance. Clear any stale file from a prior crash.
+    // No live instance. Clear any stale file from a prior crash or takeover.
     let _ = std::fs::remove_file(&path);
 
     match UnixListener::bind(&path) {
@@ -87,20 +105,85 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
     }
 }
 
+/// Send our deep-link URLs (possibly none, meaning focus-only) to the primary
+/// and wait for its ack. Any error means the primary can't be trusted with
+/// this launch and the caller should take over.
+fn signal_primary(stream: &mut UnixStream) -> std::io::Result<()> {
+    let urls: Vec<String> = std::env::args_os()
+        .filter_map(|arg| arg.into_string().ok())
+        .filter(|arg| arg.starts_with("rencal:"))
+        .collect();
+    stream.write_all(urls.join("\n").as_bytes())?;
+    // Half-close so the primary's read_to_string sees EOF while our read
+    // side stays open for the ack.
+    stream.shutdown(Shutdown::Write)?;
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    let mut ack = [0u8; 1];
+    stream.read_exact(&mut ack)
+}
+
+/// Best-effort SIGTERM for a primary that failed the handshake, so takeovers
+/// don't leave windowless background processes running (issue #114).
+fn terminate_defunct_primary(stream: &UnixStream) {
+    let mut cred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let ret = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut cred as *mut libc::ucred).cast(),
+            &mut len,
+        )
+    };
+    if ret != 0 || cred.pid <= 0 {
+        return;
+    }
+    // Guard against pid reuse: only kill a process that is still rencal.
+    let comm = std::fs::read_to_string(format!("/proc/{}/comm", cred.pid)).unwrap_or_default();
+    if comm.trim_end() != "rencal" {
+        return;
+    }
+    log::warn!("terminating defunct primary instance (pid {})", cred.pid);
+    let _ = unsafe { libc::kill(cred.pid, libc::SIGTERM) };
+}
+
+/// True once the binary this process was launched from has been replaced or
+/// removed (e.g. by a pacman upgrade, which unlinks the old file and leaves
+/// `/proc/self/exe` pointing at "... (deleted)").
+fn exe_is_stale() -> bool {
+    std::fs::read_link("/proc/self/exe")
+        .map(|target| target.to_string_lossy().ends_with(" (deleted)"))
+        .unwrap_or(false)
+}
+
 /// Spawn a thread that listens for newline-delimited URLs. An empty message
-/// represents a focus-only launch.
+/// represents a focus-only launch. `on_message` returns whether the launch
+/// was actually handled (a main window exists to show); only then do we ack —
+/// otherwise the connecting process terminates us and takes over as primary.
 pub fn spawn_listener<F>(listener: UnixListener, on_message: F)
 where
-    F: Fn(Vec<String>) + Send + 'static,
+    F: Fn(Vec<String>) -> bool + Send + 'static,
 {
     std::thread::spawn(move || {
         for incoming in listener.incoming() {
             let Ok(mut stream) = incoming else { continue };
+            let _ = stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT));
             let mut message = String::new();
             if stream.read_to_string(&mut message).is_err() {
                 continue;
             }
-            on_message(message.lines().map(String::from).collect());
+            if exe_is_stale() {
+                log::warn!("binary replaced on disk; yielding single-instance role");
+                continue;
+            }
+            if on_message(message.lines().map(String::from).collect()) {
+                let _ = stream.write_all(ACK);
+            }
         }
     });
 }

--- a/src-tauri/src/single_instance.rs
+++ b/src-tauri/src/single_instance.rs
@@ -10,6 +10,8 @@
 //! binary is still on disk (a pacman upgrade unlinks it) and it still has a
 //! main window to show. No ack means the primary is defunct — the new launch
 //! takes over the socket, instead of exiting 0 with no window ever appearing.
+//! A primary that finds its own binary replaced exits when yielding, so the
+//! takeover doesn't leave a windowless process running duplicate loops.
 
 use std::io::{Read, Write};
 use std::net::Shutdown;
@@ -78,8 +80,8 @@ pub fn try_acquire_or_signal() -> Option<InstanceGuard> {
         }
         // No ack: the primary is stale (binary replaced under it), hung, or
         // lost its window. Take over so this launch still produces a window.
-        // The defunct process just lingers without the socket until logout;
-        // killing it isn't worth the machinery (see PR #119 review).
+        // A stale primary exits itself when yielding (see spawn_listener);
+        // a hung or pre-handshake one lingers until logout.
         log::warn!("existing instance did not ack; taking over single-instance role");
     }
 
@@ -147,8 +149,13 @@ where
                 continue;
             }
             if exe_is_stale() {
-                log::warn!("binary replaced on disk; yielding single-instance role");
-                continue;
+                // Our binary was replaced on disk; the connecting launch is
+                // the new version and will take over the socket. Exit
+                // abruptly on purpose: process::exit skips
+                // InstanceGuard::drop, so we don't unlink the socket file
+                // after the successor has already bound it.
+                log::warn!("binary replaced on disk; exiting so the new launch can take over");
+                std::process::exit(0);
             }
             if on_message(message.lines().map(String::from).collect()) {
                 let _ = stream.write_all(ACK);


### PR DESCRIPTION
Upgrading the binary under a running instance can leave a windowless process holding the socket, making every later launch exit silently.

Launches now expect an ack from the primary; if none arrives, they take over the socket and start normally. A primary that detects its binary was replaced exits itself when yielding, so takeovers don't leave stale processes running duplicate reminder loops.

Fixes #114