### PR TITLE
Drag event to reschedule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Provider credential field IDs come from the caldir provider binaries.
 ## Feature-specific notes
 
 - Infinite scroll (in Month/Week views): `docs/scroll-behaviour.md`
+- Drag to reschedule (in Month/Week views): `docs/drag-to-reschedule.md`
 - Natural language input: `src/lib/magic-parser.ts`
 - Agenda keyboard nav: `src/components/sidebar/agenda/`
 - Notifications: `docs/notifications.md`, `src-tauri/reminder-core/`

--- a/docs/drag-to-reschedule.md
+++ b/docs/drag-to-reschedule.md
@@ -1,0 +1,47 @@
+# Drag to reschedule
+
+Events in the month and week views can be dragged to a new day (and, in the week
+time grid, a new time). Code: `src/contexts/EventDragContext.tsx` (session +
+DOM hit-testing), `src/lib/event-drag.ts` (pure drop math, tested), and
+`src/components/event-parts/EventDragOverlay.tsx` (the floating copy).
+
+## Interaction
+
+- A press on an event block only becomes a drag after the pointer travels a few
+  pixels, so clicks still open the popover. The release after a drag never
+  counts as a click (it would otherwise navigate to the day under the pointer).
+- While dragging: the source block stays where it was, dimmed; a floating copy
+  follows the pointer (a title pill in the month view and all-day lane, a
+  full-size block showing the new time in the week grid); a preview block with a
+  ring in the event colour sits at the snapped drop position.
+- Escape cancels. Dragging near an edge of the scroll container auto-scrolls it.
+- Dropping calls `requestSave` from `RecurrenceEditContext`, so the optimistic
+  update, rollback toast, and the recurring-event dialog behave exactly like
+  edits from the popover.
+
+## What a drop does
+
+Drops only ever shift an event: a whole-day delta, plus a wallclock-minute delta
+in the week time grid, applied to both start and end. Duration, kind (all-day vs
+timed), and the event's own timezone are all preserved.
+
+- Month cells (`data-drop-zone="day"`): any event, time of day unchanged.
+- Week all-day lane and day headers (`"all-day"`): all-day and multi-day events
+  only.
+- Week day columns (`"timed"`): single-day timed events only, snapped to
+  15 minutes and clamped inside the day.
+
+Dropping where the event can't land (or back on its own slot) shows no preview
+and does nothing on release. Read-only calendars and events the user doesn't
+organise can't be dragged (same rule as the edit popover).
+
+## Extending
+
+- A new droppable region needs `data-drop-day="YYYY-MM-DD"` and a
+  `data-drop-zone`; the pointer is resolved with `elementsFromPoint`, so blocks
+  layered over a cell don't hide it.
+- A new scrollable view opts into edge auto-scroll with `data-drag-scroll` on
+  its scroll container.
+- Blocks read their role through `useEventDragRole` and attach
+  `useEventDragHandle` as `onPointerDown`. The preview is a copy of the event
+  with a distinct id, injected into the grid layouts by `useEventsWithDrag`.

--- a/src/components/event-parts/EventDragOverlay.tsx
+++ b/src/components/event-parts/EventDragOverlay.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, type CSSProperties } from "react"
+
+import { UntitledEventText } from "@/components/ui/untitled-event-text"
+
+import { useCalendars } from "@/contexts/CalendarStateContext"
+import { useEventDrag, type ActiveEventDrag, type DragFloat } from "@/contexts/EventDragContext"
+import { useSettings } from "@/contexts/SettingsContext"
+
+import { getCalendarColor } from "@/lib/calendar-styles"
+import { getEventBlockStyle } from "@/lib/event-styles"
+import { formatTime, isAllDay } from "@/lib/event-time"
+import { cn } from "@/lib/utils"
+
+/**
+ * Full-window layer shown while an event is being dragged. It owns the grabbing
+ * cursor and carries the floating copy of the event that follows the pointer.
+ * Drop targets are hit-tested through it, so it never needs pointer events off.
+ */
+export function EventDragOverlay() {
+  const { drag } = useEventDrag()
+  if (!drag) return null
+
+  return (
+    <div className="fixed inset-0 z-50 cursor-grabbing select-none">
+      <DragFloatCard key={drag.sourceKey} drag={drag} />
+    </div>
+  )
+}
+
+function floatPosition(float: DragFloat, x: number, y: number): CSSProperties {
+  if (float.kind === "block") {
+    return {
+      left: x - float.offsetX,
+      top: y - float.offsetY,
+      width: float.width,
+      height: float.height,
+    }
+  }
+  return { left: x, top: y, transform: "translate(-12px, -50%)" }
+}
+
+function DragFloatCard({ drag }: { drag: ActiveEventDrag }) {
+  const { calendars } = useCalendars()
+  const { timeFormat } = useSettings()
+  const ref = useRef<HTMLDivElement>(null)
+  // Pointer position lives outside React state: the card re-renders only when
+  // the drop target changes, and moves via direct style writes in between.
+  const posRef = useRef(drag.pointer)
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      posRef.current = { x: e.clientX, y: e.clientY }
+      const el = ref.current
+      if (!el) return
+      const { left, top } = floatPosition(drag.float, e.clientX, e.clientY)
+      el.style.left = `${left}px`
+      el.style.top = `${top}px`
+    }
+    window.addEventListener("pointermove", onMove)
+    return () => window.removeEventListener("pointermove", onMove)
+  }, [drag.float])
+
+  const { event, float } = drag
+  const range = drag.target ?? { start: event.start, end: event.end }
+  const calendar = calendars.find((c) => c.slug === event.calendar_slug)
+  const summary = event.summary || <UntitledEventText />
+  const showTime = float.kind === "block" && !isAllDay(range.start)
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "absolute overflow-hidden rounded text-xs shadow-xl",
+        float.kind === "block" ? "px-1.5 py-1" : "px-1.5 py-0.5 whitespace-nowrap",
+      )}
+      style={{
+        ...floatPosition(float, posRef.current.x, posRef.current.y),
+        ...getEventBlockStyle({
+          calendarColor: getCalendarColor(calendar),
+          eventColor: event.color,
+          highlighted: true,
+        }),
+      }}
+    >
+      <div className="font-medium leading-tight truncate">{summary}</div>
+      {showTime && (
+        <div className="opacity-80 leading-tight truncate">
+          {formatTime(range.start, timeFormat)} – {formatTime(range.end, timeFormat)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/events-blocks/month-view/AllDayEventBlock.tsx
+++ b/src/components/events-blocks/month-view/AllDayEventBlock.tsx
@@ -4,6 +4,8 @@ import { EventContextMenu } from "@/components/EventContextMenu"
 import { LANE_GAP, LANE_HEIGHT } from "@/components/main/month-view/Row"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
+import { useEventDragHandle, useEventDragRole } from "@/contexts/EventDragContext"
+
 import type { AllDayLaneItem } from "@/hooks/cal-events/all-day-lanes"
 import { pointAnchorFromClick, setEventAnchor } from "@/lib/event-anchor"
 import { getEventBlockClasses, getEventBlockStyle } from "@/lib/event-styles"
@@ -29,13 +31,19 @@ export function MonthAllDayEvent({
   const ref = useRef<HTMLDivElement>(null)
   const [contextOpen, setContextOpen] = useState(false)
 
+  const dragRole = useEventDragRole(item.event)
+  const isDragPreview = dragRole === "preview"
+  // Drafts and drag previews are stand-ins: no click, no context menu, no drag.
+  const isStatic = isDraft || isDragPreview
+  const onDragPointerDown = useEventDragHandle(item.event, { disabled: isStatic })
+
   const highlighted = highlightedByParent || contextOpen
   const isDashed = isPending || isDeclined
 
   const fillsRow = item.endCol - item.startCol === 7
 
   const handleClick: MouseEventHandler<HTMLDivElement> | undefined = (e) => {
-    if (!isDraft) {
+    if (!isStatic) {
       e.stopPropagation()
       setEventAnchor(fillsRow ? pointAnchorFromClick(e) : e.currentTarget)
       onClick()
@@ -45,14 +53,16 @@ export function MonthAllDayEvent({
   const inner = (
     <div
       ref={ref}
-      data-event-clickable={!isDraft || undefined}
+      data-event-clickable={!isStatic || undefined}
       className={cn(
         getEventBlockClasses(highlighted, isDeclined),
         "absolute truncate px-1 py-px leading-4",
         isDashed && "opacity-50",
-        !isDraft && dimmed && "opacity-50",
+        !isStatic && dimmed && "opacity-50",
         item.isStart && "rounded-l",
         item.isEnd && "rounded-r",
+        dragRole === "source" && "opacity-40",
+        isDragPreview && "pointer-events-none",
       )}
       style={{
         top: `${item.lane * LANE_HEIGHT}px`,
@@ -65,15 +75,17 @@ export function MonthAllDayEvent({
           highlighted,
           isDashed,
           isDraft,
+          isDragPreview,
         }),
       }}
+      onPointerDown={onDragPointerDown}
       onClick={handleClick}
     >
       {item.event.summary || <UntitledEventText />}
     </div>
   )
 
-  if (isDraft) return inner
+  if (isStatic) return inner
 
   return (
     <EventContextMenu event={item.event} anchorRef={ref} onOpenChange={setContextOpen}>

--- a/src/components/events-blocks/month-view/TimedEventBlock.tsx
+++ b/src/components/events-blocks/month-view/TimedEventBlock.tsx
@@ -3,11 +3,12 @@ import { useRef, useState } from "react"
 import { EventContextMenu } from "@/components/EventContextMenu"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
+import { useEventDragHandle, useEventDragRole } from "@/contexts/EventDragContext"
 import { useSettings } from "@/contexts/SettingsContext"
 
 import type { TimedEventItem } from "@/hooks/cal-events/useMonthEventLayout"
 import { setEventAnchor } from "@/lib/event-anchor"
-import { getEventBlockColors } from "@/lib/event-styles"
+import { getEventBlockColors, getEventBlockStyle } from "@/lib/event-styles"
 import { formatTime } from "@/lib/event-time"
 import { cn } from "@/lib/utils"
 
@@ -32,6 +33,12 @@ export function MonthTimedEvent({
   const [contextOpen, setContextOpen] = useState(false)
   const { timeFormat } = useSettings()
 
+  const dragRole = useEventDragRole(item.event)
+  const isDragPreview = dragRole === "preview"
+  // Drafts and drag previews are stand-ins: no click, no context menu, no drag.
+  const isStatic = isDraft || isDragPreview
+  const onDragPointerDown = useEventDragHandle(item.event, { disabled: isStatic })
+
   const highlighted = highlightedByParent || contextOpen
 
   const colors = getEventBlockColors({
@@ -43,14 +50,16 @@ export function MonthTimedEvent({
   const inner = (
     <div
       ref={ref}
-      data-event-clickable={!isDraft || undefined}
+      data-event-clickable={!isStatic || undefined}
       className={cn(
         "flex items-center gap-1 text-xs truncate cursor-default hover:bg-hover rounded shrink-0",
         highlighted && "bg-accent!",
         (isPending || isDeclined) && "opacity-50",
-        !isDraft && dimmed && "opacity-50",
+        !isStatic && dimmed && "opacity-50",
         isDraft && "font-medium border border-dashed",
         isDeclined && "line-through",
+        dragRole === "source" && "opacity-40",
+        isDragPreview && "pointer-events-none",
       )}
       style={
         isDraft
@@ -59,10 +68,17 @@ export function MonthTimedEvent({
               borderColor: colors.borderColor,
               color: colors.textColor,
             }
-          : undefined
+          : isDragPreview
+            ? getEventBlockStyle({
+                calendarColor: item.color,
+                eventColor: item.eventColor,
+                isDragPreview: true,
+              })
+            : undefined
       }
+      onPointerDown={onDragPointerDown}
       onClick={
-        isDraft
+        isStatic
           ? undefined
           : (e) => {
               e.stopPropagation()
@@ -86,7 +102,7 @@ export function MonthTimedEvent({
     </div>
   )
 
-  if (isDraft) return inner
+  if (isStatic) return inner
 
   return (
     <EventContextMenu event={item.event} anchorRef={ref} onOpenChange={setContextOpen}>

--- a/src/components/events-blocks/week-view/AllDayEventBlock.tsx
+++ b/src/components/events-blocks/week-view/AllDayEventBlock.tsx
@@ -4,6 +4,8 @@ import { EventContextMenu } from "@/components/EventContextMenu"
 import { GUTTER_WIDTH } from "@/components/main/week-view/WeekTimeGrid"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
+import { useEventDragHandle, useEventDragRole } from "@/contexts/EventDragContext"
+
 import type { AllDayLaneItem } from "@/hooks/cal-events/all-day-lanes"
 import { pointAnchorFromClick, setEventAnchor } from "@/lib/event-anchor"
 import { getEventBlockClasses, getEventBlockStyle } from "@/lib/event-styles"
@@ -35,13 +37,19 @@ export function WeekAllDayBar({
   const ref = useRef<HTMLDivElement>(null)
   const [contextOpen, setContextOpen] = useState(false)
 
+  const dragRole = useEventDragRole(item.event)
+  const isDragPreview = dragRole === "preview"
+  // Drafts and drag previews are stand-ins: no click, no context menu, no drag.
+  const isStatic = isDraft || isDragPreview
+  const onDragPointerDown = useEventDragHandle(item.event, { disabled: isStatic })
+
   const isDashed = isPending || isDeclined
   const highlighted = highlightedByParent || contextOpen
   const fillsRow = item.endCol - item.startCol >= 7
 
   const inner = (
     <div
-      className="p-0.5 py-px pr-[3px]"
+      className={cn("p-0.5 py-px pr-[3px]", isDragPreview && "pointer-events-none")}
       style={{
         gridColumn: `${item.startCol + colOffset} / ${item.endCol + colOffset}`,
         gridRow: item.lane + 1 + rowOffset,
@@ -49,12 +57,13 @@ export function WeekAllDayBar({
     >
       <div
         ref={ref}
-        data-event-clickable={!isDraft || undefined}
+        data-event-clickable={!isStatic || undefined}
         className={cn(
           getEventBlockClasses(highlighted, isDeclined),
           "flex items-center px-1 py-px leading-4 rounded",
-          !isDraft && dimmed && "opacity-50",
+          !isStatic && dimmed && "opacity-50",
           isDraft && "font-medium",
+          dragRole === "source" && "opacity-40",
         )}
         style={getEventBlockStyle({
           calendarColor: item.calendarColor,
@@ -62,9 +71,11 @@ export function WeekAllDayBar({
           highlighted,
           isDashed,
           isDraft,
+          isDragPreview,
         })}
+        onPointerDown={onDragPointerDown}
         onClick={
-          isDraft
+          isStatic
             ? undefined
             : (e) => {
                 e.stopPropagation()
@@ -81,7 +92,7 @@ export function WeekAllDayBar({
     </div>
   )
 
-  if (isDraft) return inner
+  if (isStatic) return inner
 
   return (
     <EventContextMenu event={item.event} anchorRef={ref} onOpenChange={setContextOpen}>

--- a/src/components/events-blocks/week-view/TimedEventBlock.tsx
+++ b/src/components/events-blocks/week-view/TimedEventBlock.tsx
@@ -3,6 +3,7 @@ import { memo, useRef, useState } from "react"
 import { EventContextMenu } from "@/components/EventContextMenu"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
+import { useEventDragHandle, useEventDragRole } from "@/contexts/EventDragContext"
 import { useSettings } from "@/contexts/SettingsContext"
 
 import type { WeekTimedEventLayout } from "@/hooks/cal-events/useDayRangeLayout"
@@ -33,6 +34,16 @@ function WeekTimedEventImpl({
   const [contextOpen, setContextOpen] = useState(false)
   const { timeFormat } = useSettings()
 
+  const dragRole = useEventDragRole(layout.event)
+  const isDragPreview = dragRole === "preview"
+  // Drafts and drag previews are stand-ins: no click, no context menu, no drag.
+  const isStatic = isDraft || isDragPreview
+  // The floating copy keeps this block's size so it reads as the block being lifted.
+  const onDragPointerDown = useEventDragHandle(layout.event, {
+    disabled: isStatic,
+    float: "block",
+  })
+
   // Cascade layout: each overlap depth indents from the left by a fixed percentage and
   // extends to the right edge, so the earlier/outer event remains fully visible beneath.
   const CASCADE_OFFSET_PCT = 15
@@ -60,20 +71,23 @@ function WeekTimedEventImpl({
   const inner = (
     <div
       ref={ref}
-      data-event-clickable={!isDraft || undefined}
+      data-event-clickable={!isStatic || undefined}
       className={cn(
         getEventBlockClasses(highlighted, isDeclined),
         "absolute overflow-hidden rounded px-1",
         hasStripe && "pl-1.5",
-        !isDraft && dimmed && "opacity-50",
+        !isStatic && dimmed && "opacity-50",
         isDraft && "font-medium",
+        dragRole === "source" && "opacity-40",
+        isDragPreview && "pointer-events-none",
       )}
       style={{
         top: `${layout.top}%`,
         height: `max(${layout.height}%, 1rem)`,
         left: `${leftPercent}%`,
         width: `${widthPercent}%`,
-        zIndex: layout.column,
+        // Lift the preview above overlapping neighbours so its ring stays visible.
+        zIndex: isDragPreview ? 10 : layout.column,
         border: "1px solid var(--background)",
         ...getEventBlockStyle({
           calendarColor: layout.calendarColor,
@@ -81,10 +95,12 @@ function WeekTimedEventImpl({
           highlighted,
           isDashed,
           isDraft,
+          isDragPreview,
         }),
       }}
+      onPointerDown={onDragPointerDown}
       onClick={
-        isDraft
+        isStatic
           ? undefined
           : (e) => {
               e.stopPropagation()
@@ -134,7 +150,7 @@ function WeekTimedEventImpl({
     </div>
   )
 
-  if (isDraft) return inner
+  if (isStatic) return inner
 
   return (
     <EventContextMenu event={layout.event} anchorRef={ref} onOpenChange={setContextOpen}>

--- a/src/components/main/month-view/Cell.tsx
+++ b/src/components/main/month-view/Cell.tsx
@@ -71,6 +71,8 @@ export function MonthDayCell({
             isActiveDay && "bg-accent",
           )}
           id={isActiveDay ? ACTIVE_DAY_EL_ID : undefined}
+          data-drop-day={day.dateKey}
+          data-drop-zone="day"
           onClick={onClick}
           onContextMenu={(e) => {
             contextTargetRef.current = e.currentTarget

--- a/src/components/main/month-view/Grid.tsx
+++ b/src/components/main/month-view/Grid.tsx
@@ -277,6 +277,7 @@ export function MonthGrid({
   return (
     <div
       ref={scrollRef}
+      data-drag-scroll
       className={cn(
         "grow overflow-y-auto overflow-x-hidden relative",
         !hasInitiallyScrolled && "invisible",

--- a/src/components/main/month-view/MonthView.tsx
+++ b/src/components/main/month-view/MonthView.tsx
@@ -7,6 +7,7 @@ import { useCalEvents } from "@/contexts/CalEventsContext"
 import { useCalendarNavigation, useCalendars } from "@/contexts/CalendarStateContext"
 
 import { useEventsWithDraft } from "@/hooks/cal-events/useEventsWithDraft"
+import { useEventsWithDrag } from "@/hooks/cal-events/useEventsWithDrag"
 import { useMonthEventLayout } from "@/hooks/cal-events/useMonthEventLayout"
 import { useMonthGrid } from "@/hooks/cal-events/useMonthGrid"
 import { useVisibleCalendarIds } from "@/hooks/cal-events/useVisibleCalendarIds"
@@ -33,7 +34,8 @@ export function MonthView() {
   })
 
   const weeks = useMonthGrid(rangeStart, rangeEnd)
-  const { events, draftCalEvent } = useEventsWithDraft(calendarEvents)
+  const { events: eventsWithDraft, draftCalEvent } = useEventsWithDraft(calendarEvents)
+  const events = useEventsWithDrag(eventsWithDraft)
   const weekLayouts = useMonthEventLayout(weeks, events, calendars)
   const dimmed = useIsDimmed()
 

--- a/src/components/main/month-view/TopLeftDate.tsx
+++ b/src/components/main/month-view/TopLeftDate.tsx
@@ -20,6 +20,8 @@ export function TopLeftDate({
         day.isWeekend && "bg-weekend",
         isActive && "bg-accent",
       )}
+      data-drop-day={day.dateKey}
+      data-drop-zone="day"
       onClick={onClick}
     >
       {day.date.day === 1 && (

--- a/src/components/main/week-view/WeekTimeGrid.tsx
+++ b/src/components/main/week-view/WeekTimeGrid.tsx
@@ -243,7 +243,7 @@ export function WeekTimeGrid({
   const dayGridCols = `${GUTTER_WIDTH}px repeat(${N}, ${dayWidth}px)`
 
   return (
-    <div ref={scrollContainerRef} className="h-full w-full min-w-0 overflow-auto">
+    <div ref={scrollContainerRef} data-drag-scroll className="h-full w-full min-w-0 overflow-auto">
       <div style={{ width: totalContentWidth, minHeight: "100%" }}>
         {/* Zone 1+2: Day headers + all-day bars share one grid so column tracks
             line up exactly with the time grid below. */}
@@ -285,6 +285,8 @@ export function WeekTimeGrid({
                         : day.isWeekend && "bg-weekend",
                     )}
                     style={{ gridColumn: i + 2, gridRow: "2 / -1" }}
+                    data-drop-day={day.dateKey}
+                    data-drop-zone="all-day"
                     onContextMenu={(e) => {
                       contextTargetRef.current = e.currentTarget
                     }}
@@ -349,6 +351,8 @@ export function WeekTimeGrid({
                   } as React.CSSProperties
                 }
                 id={day.dateKey === activeDateKey ? ACTIVE_DAY_EL_ID : undefined}
+                data-drop-day={day.dateKey}
+                data-drop-zone="timed"
                 onClick={() => onDayClick(day.date)}
               >
                 {(timedByDay.get(day.dateKey) ?? []).map((layout) => {
@@ -415,6 +419,10 @@ const DayHeaders = ({
         day.dateKey === activeDateKey ? "bg-secondary-hover" : day.isWeekend && "bg-weekend",
       )}
       style={{ gridRow: 1 }}
+      // Headers double as an all-day drop zone so multi-day bars can land here
+      // even when no all-day lane is rendered yet.
+      data-drop-day={day.dateKey}
+      data-drop-zone="all-day"
       onClick={() => onDayClick(day.date)}
     >
       <span className="text-[11px] text-muted-foreground uppercase">

--- a/src/components/main/week-view/WeekView.tsx
+++ b/src/components/main/week-view/WeekView.tsx
@@ -6,6 +6,7 @@ import { useCalendarNavigation, useCalendars } from "@/contexts/CalendarStateCon
 
 import { useDayRangeLayout } from "@/hooks/cal-events/useDayRangeLayout"
 import { useEventsWithDraft } from "@/hooks/cal-events/useEventsWithDraft"
+import { useEventsWithDrag } from "@/hooks/cal-events/useEventsWithDrag"
 import { useInfiniteDays } from "@/hooks/cal-events/useInfiniteDays"
 import { useVisibleCalendarIds } from "@/hooks/cal-events/useVisibleCalendarIds"
 import { useIsDimmed } from "@/hooks/useIsDimmed"
@@ -24,7 +25,8 @@ export function WeekView() {
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const { days } = useInfiniteDays({ scrollContainerRef, activeDate, visibleCalendarIds })
-  const { events, draftCalEvent } = useEventsWithDraft(calendarEvents)
+  const { events: eventsWithDraft, draftCalEvent } = useEventsWithDraft(calendarEvents)
+  const events = useEventsWithDrag(eventsWithDraft)
   const layout = useDayRangeLayout(days, events, calendars)
   const dimmed = useIsDimmed()
 

--- a/src/contexts/EventDragContext.tsx
+++ b/src/contexts/EventDragContext.tsx
@@ -1,0 +1,353 @@
+/*
+ * Drag-to-reschedule state. One drag session at a time: a press on an event
+ * block registers a pending session; once the pointer travels past a small
+ * threshold the session activates (so plain clicks still open the popover),
+ * the source block dims in place, a floating copy follows the pointer, and a
+ * preview block renders at the snapped drop position. Releasing commits the
+ * move through `requestSave`, which handles optimistic updates, rollback, and
+ * the recurring-event dialog exactly like the edit popover does.
+ *
+ * Drop targets are discovered from the DOM: grid cells/columns declare
+ * `data-drop-day` + `data-drop-zone` (see `DropZone` in lib/event-drag), and
+ * scroll containers declare `data-drag-scroll` to opt in to edge auto-scroll.
+ */
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react"
+
+import { useCalEvents } from "@/contexts/CalEventsContext"
+import { useCalendars } from "@/contexts/CalendarStateContext"
+import { useRecurrenceEdit } from "@/contexts/RecurrenceEditContext"
+
+import { eventKey, withDates, type CalendarEvent } from "@/lib/cal-events"
+import { createDebugLogger } from "@/lib/debug"
+import {
+  computeDropRange,
+  DRAG_THRESHOLD_PX,
+  edgeScrollDelta,
+  grabFor,
+  makeDragPreview,
+  type DragGrab,
+  type DropHit,
+  type DropZone,
+} from "@/lib/event-drag"
+import {
+  DAY_MINUTES,
+  dateKeyToPlainDate,
+  formatDateKey,
+  isSameEventTime,
+  type EventTimeRange,
+} from "@/lib/event-time"
+import { isEventReadonly } from "@/lib/event-utils"
+
+const debugDrag = createDebugLogger("event-drag")
+
+/** How the floating copy under the pointer is drawn. */
+export type DragFloatKind = "pill" | "block"
+
+export interface DragFloat {
+  kind: DragFloatKind
+  width: number
+  height: number
+  /** Pointer offset from the source block's top-left corner at grab time. */
+  offsetX: number
+  offsetY: number
+}
+
+export interface ActiveEventDrag {
+  event: CalendarEvent
+  sourceKey: string
+  /** Snapped drop range, or null while hovering somewhere the event can't land. */
+  target: EventTimeRange | null
+  /** `event` moved to `target`, injected into the grid layouts; null with no target. */
+  preview: CalendarEvent | null
+  float: DragFloat
+  /** Pointer position when the drag activated; the overlay seeds from it. */
+  pointer: { x: number; y: number }
+}
+
+type StartDrag = (
+  event: CalendarEvent,
+  e: ReactPointerEvent<HTMLElement>,
+  opts: { float: DragFloatKind },
+) => void
+
+interface EventDragContextValue {
+  drag: ActiveEventDrag | null
+  startDrag: StartDrag
+}
+
+const EventDragContext = createContext<EventDragContextValue | null>(null)
+
+export function useEventDrag(): EventDragContextValue {
+  const ctx = useContext(EventDragContext)
+  if (!ctx) throw new Error("useEventDrag must be used within EventDragProvider")
+  return ctx
+}
+
+type DragSession = {
+  event: CalendarEvent
+  sourceKey: string
+  float: DragFloat
+  scrollEl: HTMLElement | null
+  startX: number
+  startY: number
+  lastX: number
+  lastY: number
+  /** Whether the press has turned into a drag. Stays true after Escape so the release click is swallowed. */
+  activated: boolean
+  cancelled: boolean
+  grab: DragGrab
+  target: EventTimeRange | null
+  raf: number | null
+}
+
+function findDropHit(x: number, y: number): DropHit | null {
+  // `elementsFromPoint` returns the full stack under the point, so a cell is
+  // found even when an event block (a sibling in the grid) sits on top of it.
+  const el = document
+    .elementsFromPoint(x, y)
+    .find(
+      (candidate): candidate is HTMLElement =>
+        candidate instanceof HTMLElement && candidate.dataset.dropDay !== undefined,
+    )
+  if (!el) return null
+
+  const zone = el.dataset.dropZone as DropZone | undefined
+  const dayKey = el.dataset.dropDay
+  if (!zone || !dayKey) return null
+
+  const day = dateKeyToPlainDate(dayKey)
+  if (zone !== "timed") return { zone, day, minutes: null }
+
+  const rect = el.getBoundingClientRect()
+  return { zone, day, minutes: ((y - rect.top) / rect.height) * DAY_MINUTES }
+}
+
+function sameRange(a: EventTimeRange | null, b: EventTimeRange | null): boolean {
+  if (!a || !b) return a === b
+  return isSameEventTime(a.start, b.start) && isSameEventTime(a.end, b.end)
+}
+
+/**
+ * The browser fires a click on the common ancestor of the press and release
+ * targets, which after a drag would land on a day cell and navigate. Swallow
+ * that one click; the listener is dropped right after in case none fires.
+ */
+function suppressNextClick() {
+  const swallow = (e: MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+  }
+  window.addEventListener("click", swallow, { capture: true, once: true })
+  setTimeout(() => window.removeEventListener("click", swallow, { capture: true }), 0)
+}
+
+export function EventDragProvider({ children }: { children: ReactNode }) {
+  const { calendarEvents, setActiveEventKey } = useCalEvents()
+  const { requestSave } = useRecurrenceEdit()
+  const [drag, setDrag] = useState<ActiveEventDrag | null>(null)
+
+  const sessionRef = useRef<DragSession | null>(null)
+  const requestSaveRef = useRef(requestSave)
+  requestSaveRef.current = requestSave
+  const calendarEventsRef = useRef(calendarEvents)
+  calendarEventsRef.current = calendarEvents
+
+  // Handlers are created once and read everything through refs so the window
+  // listeners added at press time can always be removed again.
+  const handlers = useMemo(() => {
+    const updateTarget = (s: DragSession) => {
+      const hit = findDropHit(s.lastX, s.lastY)
+      const range = hit ? computeDropRange(s.event, hit, s.grab) : null
+      if (sameRange(range, s.target)) return
+
+      s.target = range
+      debugDrag("target", {
+        zone: hit?.zone,
+        day: hit ? formatDateKey(hit.day) : null,
+        hasTarget: range !== null,
+      })
+      setDrag((prev) =>
+        prev
+          ? { ...prev, target: range, preview: range ? makeDragPreview(s.event, range) : null }
+          : prev,
+      )
+    }
+
+    const autoscrollTick = () => {
+      const s = sessionRef.current
+      if (!s || !s.activated || s.cancelled) return
+
+      const el = s.scrollEl
+      if (el) {
+        const { dx, dy } = edgeScrollDelta(el.getBoundingClientRect(), s.lastX, s.lastY, {
+          x: el.scrollWidth > el.clientWidth,
+          y: el.scrollHeight > el.clientHeight,
+        })
+        if (dx || dy) {
+          el.scrollBy(dx, dy)
+          updateTarget(s)
+        }
+      }
+      s.raf = requestAnimationFrame(autoscrollTick)
+    }
+
+    const activate = (s: DragSession) => {
+      s.activated = true
+      s.grab = grabFor(s.event, findDropHit(s.startX, s.startY))
+      debugDrag("activate", { event: s.sourceKey, grab: s.grab, float: s.float.kind })
+
+      // The edit popover would otherwise stay open on the event being moved.
+      setActiveEventKey(null)
+      setDrag({
+        event: s.event,
+        sourceKey: s.sourceKey,
+        target: null,
+        preview: null,
+        float: s.float,
+        pointer: { x: s.lastX, y: s.lastY },
+      })
+      s.raf = requestAnimationFrame(autoscrollTick)
+    }
+
+    const cancel = (s: DragSession) => {
+      if (s.cancelled) return
+      s.cancelled = true
+      s.target = null
+      debugDrag("cancel", { event: s.sourceKey })
+      setDrag(null)
+    }
+
+    const commit = (s: DragSession) => {
+      if (!s.target) return
+      // Closing the edit popover at activation may have saved other edits to this
+      // event in the meantime; move the latest copy so those aren't overwritten.
+      const original = calendarEventsRef.current.find((e) => eventKey(e) === s.sourceKey) ?? s.event
+      const current = withDates(original, s.target.start, s.target.end)
+      debugDrag("commit", { event: s.sourceKey })
+      requestSaveRef.current(current, original)
+    }
+
+    const cleanup = () => {
+      const s = sessionRef.current
+      if (!s) return
+      if (s.raf !== null) cancelAnimationFrame(s.raf)
+      sessionRef.current = null
+      window.removeEventListener("pointermove", onPointerMove)
+      window.removeEventListener("pointerup", onPointerUp)
+      window.removeEventListener("pointercancel", onPointerCancel)
+      window.removeEventListener("keydown", onKeyDown)
+      setDrag(null)
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      const s = sessionRef.current
+      if (!s || s.cancelled) return
+      s.lastX = e.clientX
+      s.lastY = e.clientY
+
+      if (!s.activated) {
+        if (Math.hypot(e.clientX - s.startX, e.clientY - s.startY) < DRAG_THRESHOLD_PX) return
+        activate(s)
+      }
+      updateTarget(s)
+    }
+
+    const onPointerUp = () => {
+      const s = sessionRef.current
+      if (!s) return
+      if (s.activated) {
+        suppressNextClick()
+        if (!s.cancelled) commit(s)
+      }
+      cleanup()
+    }
+
+    const onPointerCancel = () => {
+      const s = sessionRef.current
+      if (s) cancel(s)
+      cleanup()
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const s = sessionRef.current
+      if (!s || e.key !== "Escape") return
+      e.preventDefault()
+      cancel(s)
+    }
+
+    const start: StartDrag = (event, e, opts) => {
+      if (e.button !== 0 || sessionRef.current) return
+
+      const el = e.currentTarget
+      const rect = el.getBoundingClientRect()
+      sessionRef.current = {
+        event,
+        sourceKey: eventKey(event),
+        float: {
+          kind: opts.float,
+          width: rect.width,
+          height: rect.height,
+          offsetX: e.clientX - rect.left,
+          offsetY: e.clientY - rect.top,
+        },
+        scrollEl: el.closest<HTMLElement>("[data-drag-scroll]"),
+        startX: e.clientX,
+        startY: e.clientY,
+        lastX: e.clientX,
+        lastY: e.clientY,
+        activated: false,
+        cancelled: false,
+        grab: { dayOffset: 0, minuteOffset: 0 },
+        target: null,
+        raf: null,
+      }
+      window.addEventListener("pointermove", onPointerMove)
+      window.addEventListener("pointerup", onPointerUp)
+      window.addEventListener("pointercancel", onPointerCancel)
+      window.addEventListener("keydown", onKeyDown)
+    }
+
+    return { start }
+  }, [setActiveEventKey])
+
+  const value = useMemo<EventDragContextValue>(
+    () => ({ drag, startDrag: handlers.start }),
+    [drag, handlers],
+  )
+
+  return <EventDragContext.Provider value={value}>{children}</EventDragContext.Provider>
+}
+
+/**
+ * `onPointerDown` for an event block, or undefined when the block can't be
+ * dragged (drafts, previews, read-only calendars, events the user doesn't own).
+ */
+export function useEventDragHandle(
+  event: CalendarEvent,
+  { disabled = false, float = "pill" }: { disabled?: boolean; float?: DragFloatKind } = {},
+): ((e: ReactPointerEvent<HTMLElement>) => void) | undefined {
+  const { startDrag } = useEventDrag()
+  const { calendars } = useCalendars()
+
+  if (disabled || isEventReadonly(event, calendars)) return undefined
+  return (e) => startDrag(event, e, { float })
+}
+
+export type EventDragRole = "source" | "preview" | null
+
+/** Whether this block is the event being dragged (drawn dimmed) or its drop preview. */
+export function useEventDragRole(event: CalendarEvent): EventDragRole {
+  const { drag } = useEventDrag()
+  if (!drag) return null
+  if (drag.preview === event) return "preview"
+  if (eventKey(event) === drag.sourceKey) return "source"
+  return null
+}

--- a/src/hooks/cal-events/useEventsWithDrag.ts
+++ b/src/hooks/cal-events/useEventsWithDrag.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react"
+
+import { useEventDrag } from "@/contexts/EventDragContext"
+
+import type { CalendarEvent } from "@/lib/cal-events"
+
+/**
+ * Adds the drag-to-reschedule preview to the events a grid lays out, so it
+ * lands in its natural lane/slot at the drop position. The source event stays
+ * in the list (blocks dim it via `useEventDragRole`).
+ */
+export function useEventsWithDrag(events: CalendarEvent[]): CalendarEvent[] {
+  const { drag } = useEventDrag()
+  const preview = drag?.preview ?? null
+
+  return useMemo(() => (preview ? [...events, preview] : events), [events, preview])
+}

--- a/src/lib/event-drag.test.ts
+++ b/src/lib/event-drag.test.ts
@@ -1,0 +1,223 @@
+import { Temporal } from "@js-temporal/polyfill"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import type { CalendarEvent } from "@/lib/cal-events"
+import {
+  allDayDate,
+  atTime,
+  computeEventDateInfo,
+  getViewerTzid,
+  setViewerTzid,
+  toViewerZonedDateTime,
+  type EventTime,
+} from "@/lib/event-time"
+
+import { computeDropRange, edgeScrollDelta, grabFor, makeDragPreview } from "./event-drag"
+
+function makeEvent(start: EventTime, end: EventTime): CalendarEvent {
+  return {
+    id: "event",
+    recurring_event_id: null,
+    summary: "Book pub quiz",
+    description: null,
+    location: null,
+    start,
+    end,
+    status: "confirmed",
+    recurrence: null,
+    master_recurrence: null,
+    reminders: [],
+    organizer: null,
+    attendees: [],
+    conference: null,
+    calendar_slug: "calendar",
+    color: null,
+    updated: null,
+    dateInfo: computeEventDateInfo(start, end),
+  }
+}
+
+const day = (key: string) => Temporal.PlainDate.from(key)
+
+function wallclock(et: EventTime): string {
+  const z = toViewerZonedDateTime(et)
+  return `${z.toPlainDate().toString()} ${String(z.hour).padStart(2, "0")}:${String(z.minute).padStart(2, "0")}`
+}
+
+describe("computeDropRange", () => {
+  const originalTz = getViewerTzid()
+  beforeEach(() => setViewerTzid("Europe/Stockholm"))
+  afterEach(() => setViewerTzid(originalTz))
+
+  const noGrab = { dayOffset: 0, minuteOffset: 0 }
+
+  it("moves a timed event to another month cell, keeping its wallclock and duration", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 17), atTime(day("2025-07-12"), 19, 30))
+
+    const range = computeDropRange(
+      event,
+      { zone: "day", day: day("2025-07-14"), minutes: null },
+      noGrab,
+    )
+
+    expect(range).not.toBeNull()
+    expect(wallclock(range!.start)).toBe("2025-07-14 17:00")
+    expect(wallclock(range!.end)).toBe("2025-07-14 19:30")
+    expect(range!.start.kind).toBe("datetime_zoned")
+  })
+
+  it("returns null when dropped back onto its own day", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 17), atTime(day("2025-07-12"), 18))
+
+    expect(
+      computeDropRange(event, { zone: "day", day: day("2025-07-12"), minutes: null }, noGrab),
+    ).toBeNull()
+  })
+
+  it("moves an all-day event by whole days", () => {
+    const event = makeEvent(allDayDate(day("2025-07-12")), allDayDate(day("2025-07-13")))
+
+    const range = computeDropRange(
+      event,
+      { zone: "day", day: day("2025-07-20"), minutes: null },
+      noGrab,
+    )
+
+    expect(range).toEqual({
+      start: allDayDate(day("2025-07-20")),
+      end: allDayDate(day("2025-07-21")),
+    })
+  })
+
+  it("keeps the grabbed day under the pointer for a multi-day event", () => {
+    // Runs Mon 7 → Wed 9 (DTEND exclusive Thu 10), grabbed on Wed.
+    const event = makeEvent(allDayDate(day("2025-07-07")), allDayDate(day("2025-07-10")))
+    const grab = grabFor(event, { zone: "day", day: day("2025-07-09"), minutes: null })
+    expect(grab.dayOffset).toBe(2)
+
+    const range = computeDropRange(
+      event,
+      { zone: "day", day: day("2025-07-16"), minutes: null },
+      grab,
+    )
+
+    expect(range).toEqual({
+      start: allDayDate(day("2025-07-14")),
+      end: allDayDate(day("2025-07-17")),
+    })
+  })
+
+  it("re-times a timed event in the week grid, snapping to 15 minutes and honouring the grab offset", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 19), atTime(day("2025-07-12"), 20))
+    // Grabbed 7 minutes into the block.
+    const grab = grabFor(event, { zone: "timed", day: day("2025-07-12"), minutes: 19 * 60 + 7 })
+    expect(grab.minuteOffset).toBe(7)
+
+    // Pointer at 18:12 on the next day → block top at 18:05 → snaps to 18:00.
+    const range = computeDropRange(
+      event,
+      { zone: "timed", day: day("2025-07-13"), minutes: 18 * 60 + 12 },
+      grab,
+    )
+
+    expect(wallclock(range!.start)).toBe("2025-07-13 18:00")
+    expect(wallclock(range!.end)).toBe("2025-07-13 19:00")
+  })
+
+  it("clamps a timed drop so the event stays inside the day", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 9), atTime(day("2025-07-12"), 11))
+
+    const late = computeDropRange(
+      event,
+      { zone: "timed", day: day("2025-07-12"), minutes: 23 * 60 + 30 },
+      noGrab,
+    )
+    expect(wallclock(late!.start)).toBe("2025-07-12 22:00")
+    expect(wallclock(late!.end)).toBe("2025-07-13 00:00")
+
+    const early = computeDropRange(
+      event,
+      { zone: "timed", day: day("2025-07-12"), minutes: -40 },
+      noGrab,
+    )
+    expect(wallclock(early!.start)).toBe("2025-07-12 00:00")
+  })
+
+  it("treats an event ending at midnight as lasting until midnight when clamping", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 22), atTime(day("2025-07-13"), 0))
+
+    const range = computeDropRange(
+      event,
+      { zone: "timed", day: day("2025-07-12"), minutes: 18 * 60 },
+      noGrab,
+    )
+
+    expect(wallclock(range!.start)).toBe("2025-07-12 18:00")
+    expect(wallclock(range!.end)).toBe("2025-07-12 20:00")
+  })
+
+  it("rejects kind changes between the all-day lane and the time grid", () => {
+    const timed = makeEvent(atTime(day("2025-07-12"), 9), atTime(day("2025-07-12"), 10))
+    const allDay = makeEvent(allDayDate(day("2025-07-12")), allDayDate(day("2025-07-13")))
+
+    expect(
+      computeDropRange(timed, { zone: "all-day", day: day("2025-07-14"), minutes: null }, noGrab),
+    ).toBeNull()
+    expect(
+      computeDropRange(allDay, { zone: "timed", day: day("2025-07-14"), minutes: 600 }, noGrab),
+    ).toBeNull()
+  })
+
+  it("moves a multi-day timed event across the all-day lane by whole days", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 20), atTime(day("2025-07-13"), 10))
+
+    const range = computeDropRange(
+      event,
+      { zone: "all-day", day: day("2025-07-15"), minutes: null },
+      noGrab,
+    )
+
+    expect(wallclock(range!.start)).toBe("2025-07-15 20:00")
+    expect(wallclock(range!.end)).toBe("2025-07-16 10:00")
+  })
+})
+
+describe("makeDragPreview", () => {
+  it("recomputes dateInfo and gives the preview its own id", () => {
+    const event = makeEvent(atTime(day("2025-07-12"), 9), atTime(day("2025-07-12"), 10))
+    const preview = makeDragPreview(event, {
+      start: atTime(day("2025-07-14"), 9),
+      end: atTime(day("2025-07-14"), 10),
+    })
+
+    expect(preview.id).not.toBe(event.id)
+    expect(preview.dateInfo.firstDay).toBe(event.dateInfo.firstDay + 2)
+  })
+})
+
+describe("edgeScrollDelta", () => {
+  const rect = { left: 100, top: 100, right: 500, bottom: 400 }
+  const both = { x: true, y: true }
+
+  it("is zero away from the edges", () => {
+    expect(edgeScrollDelta(rect, 300, 250, both)).toEqual({ dx: 0, dy: 0 })
+  })
+
+  it("scrolls towards the edge the pointer is near, faster the closer it gets", () => {
+    const near = edgeScrollDelta(rect, 470, 250, both)
+    const nearer = edgeScrollDelta(rect, 495, 250, both)
+    expect(near.dx).toBeGreaterThan(0)
+    expect(nearer.dx).toBeGreaterThan(near.dx)
+    expect(near.dy).toBe(0)
+
+    expect(edgeScrollDelta(rect, 300, 105, both).dy).toBeLessThan(0)
+  })
+
+  it("ignores axes the container cannot scroll", () => {
+    expect(edgeScrollDelta(rect, 495, 105, { x: false, y: true })).toMatchObject({ dx: 0 })
+  })
+
+  it("stops when the pointer is far outside the container", () => {
+    expect(edgeScrollDelta(rect, 800, 250, both)).toEqual({ dx: 0, dy: 0 })
+  })
+})

--- a/src/lib/event-drag.ts
+++ b/src/lib/event-drag.ts
@@ -1,0 +1,144 @@
+/*
+ * Drag-to-reschedule math. Pure helpers shared by the drag controller in
+ * `EventDragContext`; DOM hit-testing lives there, not here.
+ *
+ * A drag moves an event by a whole-day delta (month cells, all-day lanes) and,
+ * in the week time grid, an additional wallclock-minute delta. Deltas are
+ * applied to both start and end so the duration and the event's own timezone
+ * are preserved: dragging never re-zones or re-kinds an event.
+ */
+import { Temporal } from "@js-temporal/polyfill"
+
+import { withDates, type CalendarEvent } from "@/lib/cal-events"
+import { addDays, addMinutes, DAY_MINUTES, epochDay, type EventTimeRange } from "@/lib/event-time"
+import { isSpanning } from "@/lib/event-utils"
+
+/**
+ * Grid regions an event can be dropped on, declared via `data-drop-zone` on the
+ * DOM together with `data-drop-day` (a `YYYY-MM-DD` key):
+ *
+ * - "day": a month-view cell. Any event, keeps its wallclock time.
+ * - "all-day": the week view's all-day lane. Spanning events only.
+ * - "timed": a week-view day column. Single-day timed events only.
+ */
+export type DropZone = "day" | "all-day" | "timed"
+
+/** Where the pointer currently is, resolved from the DOM. */
+export type DropHit = {
+  zone: DropZone
+  day: Temporal.PlainDate
+  /** Viewer-zone wallclock minutes-of-day under the pointer; "timed" zone only. */
+  minutes: number | null
+}
+
+/**
+ * Where the event was grabbed relative to its own start, so the block follows
+ * the pointer instead of snapping its start to it. A multi-day bar grabbed on
+ * its third day keeps that day under the pointer; a timed block grabbed near its
+ * bottom keeps that offset as it moves.
+ */
+export type DragGrab = {
+  dayOffset: number
+  minuteOffset: number
+}
+
+/** Timed drops snap to this many minutes. */
+export const DRAG_SNAP_MINUTES = 15
+
+/** Pointer travel before a press turns into a drag, so plain clicks still open the event. */
+export const DRAG_THRESHOLD_PX = 4
+
+/** Distance from a scroll container's edge within which dragging auto-scrolls it. */
+export const AUTOSCROLL_EDGE_PX = 48
+const AUTOSCROLL_MAX_STEP_PX = 16
+
+export function grabFor(event: CalendarEvent, hit: DropHit | null): DragGrab {
+  if (!hit) return { dayOffset: 0, minuteOffset: 0 }
+  return {
+    dayOffset: epochDay(hit.day) - event.dateInfo.firstDay,
+    minuteOffset: hit.minutes == null ? 0 : hit.minutes - event.dateInfo.startLocalMinutes,
+  }
+}
+
+/** Duration of a single-day timed event; an event ending at midnight counts to midnight. */
+function timedDurationMinutes(event: CalendarEvent): number {
+  const { startLocalMinutes, endLocalMinutes, firstDay, endDay } = event.dateInfo
+  return endDay > firstDay ? DAY_MINUTES - startLocalMinutes : endLocalMinutes - startLocalMinutes
+}
+
+function shiftRange(event: CalendarEvent, days: number, minutes: number): EventTimeRange {
+  return {
+    start: addDays(addMinutes(event.start, minutes), days),
+    end: addDays(addMinutes(event.end, minutes), days),
+  }
+}
+
+/**
+ * The range the event would occupy if dropped at `hit`, or null when the drop
+ * is not allowed there or would leave the event exactly where it is.
+ */
+export function computeDropRange(
+  event: CalendarEvent,
+  hit: DropHit,
+  grab: DragGrab,
+): EventTimeRange | null {
+  const spanning = isSpanning(event)
+  const dayDelta = epochDay(hit.day) - grab.dayOffset - event.dateInfo.firstDay
+
+  if (hit.zone === "timed") {
+    if (spanning || hit.minutes == null) return null
+
+    const duration = timedDurationMinutes(event)
+    const snapped =
+      Math.round((hit.minutes - grab.minuteOffset) / DRAG_SNAP_MINUTES) * DRAG_SNAP_MINUTES
+    // Keep the whole event inside the day it was dropped on.
+    const maxStart = Math.max(0, DAY_MINUTES - duration)
+    const newStart = Math.min(maxStart, Math.max(0, snapped))
+    const minuteDelta = newStart - event.dateInfo.startLocalMinutes
+
+    if (dayDelta === 0 && minuteDelta === 0) return null
+    return shiftRange(event, dayDelta, minuteDelta)
+  }
+
+  if (hit.zone === "all-day" && !spanning) return null
+  if (dayDelta === 0) return null
+  return shiftRange(event, dayDelta, 0)
+}
+
+/**
+ * A stand-in rendered at the drop position while dragging. It gets its own id
+ * so it never collides with the (still rendered, dimmed) source event in React
+ * keys or the active-event tracker.
+ */
+export function makeDragPreview(event: CalendarEvent, range: EventTimeRange): CalendarEvent {
+  return { ...withDates(event, range.start, range.end), id: `${event.id}__drag-preview` }
+}
+
+/**
+ * How far a scroll container should scroll this frame given the pointer's
+ * position: nothing while the pointer is away from its edges, ramping up to a
+ * max step as the pointer reaches (or passes just beyond) an edge.
+ */
+export function edgeScrollDelta(
+  rect: { left: number; top: number; right: number; bottom: number },
+  x: number,
+  y: number,
+  axes: { x: boolean; y: boolean },
+): { dx: number; dy: number } {
+  const edge = AUTOSCROLL_EDGE_PX
+  const outside =
+    x < rect.left - edge || x > rect.right + edge || y < rect.top - edge || y > rect.bottom + edge
+  if (outside) return { dx: 0, dy: 0 }
+
+  const ramp = (depth: number) => Math.ceil(Math.min(1, depth / edge) * AUTOSCROLL_MAX_STEP_PX)
+  const along = (pos: number, min: number, max: number) => {
+    if (pos < min + edge) return -ramp(min + edge - pos)
+    if (pos > max - edge) return ramp(pos - (max - edge))
+    return 0
+  }
+
+  return {
+    dx: axes.x ? along(x, rect.left, rect.right) : 0,
+    dy: axes.y ? along(y, rect.top, rect.bottom) : 0,
+  }
+}

--- a/src/lib/event-styles.ts
+++ b/src/lib/event-styles.ts
@@ -64,12 +64,15 @@ export function getEventBlockStyle({
   highlighted,
   isDashed,
   isDraft,
+  isDragPreview,
 }: {
   calendarColor: string | null
   eventColor: string | null
   highlighted?: boolean
   isDashed?: boolean
   isDraft?: boolean
+  /** Drop-position stand-in while dragging: normal fill with a solid ring in the event colour. */
+  isDragPreview?: boolean
 }): CSSProperties {
   const { borderColor, textColor, backgroundColor } = getEventBlockColors({
     calendarColor,
@@ -85,6 +88,14 @@ export function getEventBlockStyle({
       backgroundColor,
       color: textColor,
       boxShadow: `0 0 0 2px color-mix(in srgb, ${borderColor} 25%, transparent)`,
+    }
+  }
+
+  if (isDragPreview) {
+    return {
+      backgroundColor,
+      color: textColor,
+      boxShadow: `0 0 0 1.5px ${borderColor}`,
     }
   }
 

--- a/src/lib/event-time/index.ts
+++ b/src/lib/event-time/index.ts
@@ -46,7 +46,13 @@ export {
 } from "./edit"
 export { getViewerTzid, setViewerTzid, subscribeViewerTzid } from "./local-zone"
 export { computeEventDateInfo } from "./layout"
-export { dateInViewerZone, isAllDay, isSameDay, toViewerZonedDateTime } from "./projections"
+export {
+  dateInViewerZone,
+  isAllDay,
+  isSameDay,
+  isSameEventTime,
+  toViewerZonedDateTime,
+} from "./projections"
 export {
   coversFullDay,
   displayEndDate,

--- a/src/lib/event-time/projections.ts
+++ b/src/lib/event-time/projections.ts
@@ -57,3 +57,17 @@ export function dateInViewerZone(et: EventTime): Temporal.PlainDate {
 export function isSameDay(a: EventTime, b: EventTime): boolean {
   return dateInViewerZone(a).equals(dateInViewerZone(b))
 }
+
+/** Whether two event times are the same kind and the same value (zone included). */
+export function isSameEventTime(a: EventTime, b: EventTime): boolean {
+  switch (a.kind) {
+    case "date":
+      return b.kind === "date" && a.value.equals(b.value)
+    case "datetime_utc":
+      return b.kind === "datetime_utc" && a.value.equals(b.value)
+    case "datetime_floating":
+      return b.kind === "datetime_floating" && a.value.equals(b.value)
+    case "datetime_zoned":
+      return b.kind === "datetime_zoned" && a.value.equals(b.value)
+  }
+}

--- a/src/windows/AppWindow.tsx
+++ b/src/windows/AppWindow.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from "sonner"
 
+import { EventDragOverlay } from "@/components/event-parts/EventDragOverlay"
 import { PopoverEditEvent } from "@/components/event-parts/PopoverEditEvent"
 import { PopoverNewEvent } from "@/components/event-parts/PopoverNewEvent"
 import { SheetEvent } from "@/components/event-parts/SheetInfo"
@@ -14,6 +15,7 @@ import { AgendaFocusProvider } from "@/contexts/AgendaFocusContext"
 import { CalEventsProvider } from "@/contexts/CalEventsContext"
 import { CreateEventGateProvider } from "@/contexts/CreateEventGateContext"
 import { EventDraftProvider } from "@/contexts/EventDraftContext"
+import { EventDragProvider } from "@/contexts/EventDragContext"
 import { RecurrenceEditProvider } from "@/contexts/RecurrenceEditContext"
 import { SidebarCollapseProvider, useSidebarCollapse } from "@/contexts/SidebarCollapseContext"
 import { SyncProvider } from "@/contexts/SyncContext"
@@ -27,15 +29,17 @@ export function AppWindow({ preload }: { preload: Preload }) {
     <CalEventsProvider initialEvents={preload.initialEvents} initialRange={preload.initialRange}>
       <SyncProvider>
         <RecurrenceEditProvider>
-          <EventDraftProvider>
-            <CreateEventGateProvider>
-              <AgendaFocusProvider>
-                <SidebarCollapseProvider>
-                  <App />
-                </SidebarCollapseProvider>
-              </AgendaFocusProvider>
-            </CreateEventGateProvider>
-          </EventDraftProvider>
+          <EventDragProvider>
+            <EventDraftProvider>
+              <CreateEventGateProvider>
+                <AgendaFocusProvider>
+                  <SidebarCollapseProvider>
+                    <App />
+                  </SidebarCollapseProvider>
+                </AgendaFocusProvider>
+              </CreateEventGateProvider>
+            </EventDraftProvider>
+          </EventDragProvider>
         </RecurrenceEditProvider>
         <MassDeleteConfirmDialog />
         <UpdateChecker />
@@ -62,6 +66,7 @@ function App() {
 
       {isMd && <PopoverEditEvent />}
       {isMd && <PopoverNewEvent />}
+      {isMd && <EventDragOverlay />}
 
       {!isMd && <SheetEvent />}
     </main>


### PR DESCRIPTION
Make it easy to visually reschedule events through drag and drop. Work in both the week view and the month view.

https://github.com/user-attachments/assets/831c0957-a986-4053-932d-36a3e3587172

