### PR TITLE
UX tweaks for video events in Agenda view

### DIFF
--- a/src/components/events-blocks/agenda/TimedEventBlock.tsx
+++ b/src/components/events-blocks/agenda/TimedEventBlock.tsx
@@ -1,15 +1,18 @@
-import { memo } from "react"
+import { openUrl } from "@tauri-apps/plugin-opener"
+import { memo, type MouseEvent } from "react"
 
+import { Button } from "@/components/ui/button"
 import { UntitledEventText } from "@/components/ui/untitled-event-text"
 
 import type { TimeFormat } from "@/rpc/bindings"
 
 import { useSettings } from "@/contexts/SettingsContext"
 
+import { useNow } from "@/hooks/useNow"
 import { CalendarEvent } from "@/lib/cal-events"
-import { hasVideoMeeting } from "@/lib/conference"
+import { getMeetingUrl, hasVideoMeeting, isWithinJoinWindow } from "@/lib/conference"
 import { getEventBlockColors } from "@/lib/event-styles"
-import { formatDateKey, formatTime, isSameDay } from "@/lib/event-time"
+import { type EventDateInfo, formatDateKey, formatTime, isSameDay } from "@/lib/event-time"
 
 import { VideoIcon } from "@/icons/video"
 
@@ -26,20 +29,52 @@ export const AgendaTimedEventBlock = memo(function EventRow({
 
   const colors = getEventBlockColors({ calendarColor, eventColor: event.color })
   const timeLabel = getTimeLabel(event, dateKey, timeFormat)
+  const meetingUrl = getMeetingUrl(event)
 
   return (
     <div className="flex gap-3 pl-3.5 pr-2">
       <div className="w-[3px] shrink-0 rounded" style={{ backgroundColor: colors.borderColor }} />
-      <div className="relative text-sm">
+      <div className="relative flex-1 min-w-0 text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground numerical text-xs h-4">
           <span>{timeLabel}</span>
           {hasVideoMeeting(event) && <VideoIcon className="size-3 shrink-0" />}
         </div>
         <div className="font-medium">{event.summary || <UntitledEventText />}</div>
       </div>
+      {meetingUrl && <JoinMeetingButton url={meetingUrl} dateInfo={event.dateInfo} />}
     </div>
   )
 })
+
+/**
+ * Rendered only while the meeting is about to start or in progress. Lives in
+ * its own component so only rows with a meeting link subscribe to the clock.
+ */
+function JoinMeetingButton({ url, dateInfo }: { url: string; dateInfo: EventDateInfo }) {
+  const nowMs = useNow()
+
+  if (!isWithinJoinWindow(dateInfo, nowMs)) return null
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    // Joining must not also toggle the row's event popover.
+    e.stopPropagation()
+    openUrl(url)
+  }
+
+  return (
+    <Button
+      size="sm"
+      round
+      tabIndex={-1}
+      className="self-center h-6 px-2.5 text-xs"
+      // Keep focus on the agenda row so keyboard navigation isn't disturbed.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={handleClick}
+    >
+      Join
+    </Button>
+  )
+}
 
 /**
  * A multi-day timed event only appears as a timed row on the days it partially

--- a/src/components/events-blocks/agenda/TimedEventBlock.tsx
+++ b/src/components/events-blocks/agenda/TimedEventBlock.tsx
@@ -7,8 +7,11 @@ import type { TimeFormat } from "@/rpc/bindings"
 import { useSettings } from "@/contexts/SettingsContext"
 
 import { CalendarEvent } from "@/lib/cal-events"
+import { hasVideoMeeting } from "@/lib/conference"
 import { getEventBlockColors } from "@/lib/event-styles"
 import { formatDateKey, formatTime, isSameDay } from "@/lib/event-time"
+
+import { VideoIcon } from "@/icons/video"
 
 export const AgendaTimedEventBlock = memo(function EventRow({
   event,
@@ -28,7 +31,10 @@ export const AgendaTimedEventBlock = memo(function EventRow({
     <div className="flex gap-3 pl-3.5 pr-2">
       <div className="w-[3px] shrink-0 rounded" style={{ backgroundColor: colors.borderColor }} />
       <div className="relative text-sm">
-        <div className="text-muted-foreground numerical text-xs h-4">{timeLabel}</div>
+        <div className="flex items-center gap-1.5 text-muted-foreground numerical text-xs h-4">
+          <span>{timeLabel}</span>
+          {hasVideoMeeting(event) && <VideoIcon className="size-3 shrink-0" />}
+        </div>
         <div className="font-medium">{event.summary || <UntitledEventText />}</div>
       </div>
     </div>

--- a/src/hooks/cal-events/all-day-lanes.test.ts
+++ b/src/hooks/cal-events/all-day-lanes.test.ts
@@ -11,6 +11,7 @@ function event(id: string, firstDay: number, lastDay: number): CalendarEvent {
       firstDay,
       lastDay,
       startMs: 0,
+      endMs: 0,
       endDay: lastDay,
       startLocalMinutes: 0,
       endLocalMinutes: 0,

--- a/src/hooks/useNow.ts
+++ b/src/hooks/useNow.ts
@@ -1,0 +1,62 @@
+import { Temporal } from "@js-temporal/polyfill"
+import { useSyncExternalStore } from "react"
+
+/*
+ * One app-wide clock, shared by every subscriber, that ticks on the minute
+ * boundary so time-sensitive UI (e.g. the agenda's "Join" buttons) flips the
+ * moment the wallclock minute changes. N subscribers cost one timer, not N.
+ */
+
+const listeners = new Set<() => void>()
+let nowMs = readNow()
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function readNow(): number {
+  return Temporal.Now.instant().epochMilliseconds
+}
+
+function tick() {
+  nowMs = readNow()
+  for (const listener of listeners) listener()
+  scheduleNextMinute()
+}
+
+function scheduleNextMinute() {
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(tick, 60_000 - (readNow() % 60_000))
+}
+
+// Timers are throttled while the window is hidden, so catch up as soon as it
+// becomes visible again instead of waiting for the stale timeout.
+function handleVisibilityChange() {
+  if (document.visibilityState === "visible") tick()
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+
+  if (listeners.size === 1) {
+    nowMs = readNow()
+    scheduleNextMinute()
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+  }
+
+  return () => {
+    listeners.delete(listener)
+
+    if (listeners.size === 0) {
+      if (timer) clearTimeout(timer)
+      timer = null
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }
+}
+
+function getSnapshot(): number {
+  return nowMs
+}
+
+/** The current instant in epoch ms, re-rendering once per minute. */
+export function useNow(): number {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/src/lib/conference.test.ts
+++ b/src/lib/conference.test.ts
@@ -7,7 +7,10 @@ import {
   conferenceForCalendar,
   conferenceToRpc,
   detectConference,
+  getMeetingUrl,
   hasVideoMeeting,
+  isWithinJoinWindow,
+  JOIN_LEAD_MINUTES,
   rpcToConference,
   type EventConference,
 } from "@/lib/conference"
@@ -119,5 +122,47 @@ describe("hasVideoMeeting", () => {
   it("is false without a conference or meeting link", () => {
     expect(hasVideoMeeting({ conference: null, location: null })).toBe(false)
     expect(hasVideoMeeting({ conference: null, location: "Room 4B" })).toBe(false)
+  })
+})
+
+describe("getMeetingUrl", () => {
+  it("prefers a live conference over a link in the location", () => {
+    const live: EventConference = {
+      status: "live",
+      provider: "google",
+      url: "https://meet.google.com/abc-defg-hij",
+    }
+
+    expect(getMeetingUrl({ conference: live, location: "https://zoom.us/j/123456789" })).toBe(
+      live.url,
+    )
+  })
+
+  it("falls back to a meeting link in the location", () => {
+    expect(getMeetingUrl({ conference: null, location: "https://zoom.us/j/123456789" })).toBe(
+      "https://zoom.us/j/123456789",
+    )
+  })
+
+  it("has no link for requested conferences or plain locations", () => {
+    const requested: EventConference = { status: "requested", provider: "google" }
+
+    expect(getMeetingUrl({ conference: requested, location: null })).toBeNull()
+    expect(getMeetingUrl({ conference: null, location: "Room 4B" })).toBeNull()
+  })
+})
+
+describe("isWithinJoinWindow", () => {
+  const minute = 60_000
+  const dateInfo = { startMs: 100 * minute, endMs: 130 * minute }
+
+  it("opens the lead time before the start and stays open until the end", () => {
+    const opensAt = dateInfo.startMs - JOIN_LEAD_MINUTES * minute
+
+    expect(isWithinJoinWindow(dateInfo, opensAt - 1)).toBe(false)
+    expect(isWithinJoinWindow(dateInfo, opensAt)).toBe(true)
+    expect(isWithinJoinWindow(dateInfo, dateInfo.startMs)).toBe(true)
+    expect(isWithinJoinWindow(dateInfo, dateInfo.endMs - 1)).toBe(true)
+    expect(isWithinJoinWindow(dateInfo, dateInfo.endMs)).toBe(false)
   })
 })

--- a/src/lib/conference.test.ts
+++ b/src/lib/conference.test.ts
@@ -7,6 +7,7 @@ import {
   conferenceForCalendar,
   conferenceToRpc,
   detectConference,
+  hasVideoMeeting,
   rpcToConference,
   type EventConference,
 } from "@/lib/conference"
@@ -93,5 +94,30 @@ describe("conference RPC conversion", () => {
     { status: "live", provider: "proton", url: "https://meet.proton.me/example" },
   ])("round-trips $status conferences", (conference) => {
     expect(rpcToConference(conferenceToRpc(conference))).toEqual(conference)
+  })
+})
+
+describe("hasVideoMeeting", () => {
+  it("is true for stored conferences, live or requested", () => {
+    const live: EventConference = {
+      status: "live",
+      provider: "google",
+      url: "https://meet.google.com/abc-defg-hij",
+    }
+    const requested: EventConference = { status: "requested", provider: "google" }
+
+    expect(hasVideoMeeting({ conference: live, location: null })).toBe(true)
+    expect(hasVideoMeeting({ conference: requested, location: null })).toBe(true)
+  })
+
+  it("is true for a meeting link in the location", () => {
+    expect(hasVideoMeeting({ conference: null, location: "https://zoom.us/j/123456789" })).toBe(
+      true,
+    )
+  })
+
+  it("is false without a conference or meeting link", () => {
+    expect(hasVideoMeeting({ conference: null, location: null })).toBe(false)
+    expect(hasVideoMeeting({ conference: null, location: "Room 4B" })).toBe(false)
   })
 })

--- a/src/lib/conference.ts
+++ b/src/lib/conference.ts
@@ -41,6 +41,16 @@ export const detectConference = (text: string | null | undefined): DetectedConfe
   return null
 }
 
+/**
+ * Whether an event has a video meeting: either a stored conference (live or
+ * requested) or a known meeting link in its location, mirroring what the
+ * event popover's conference section would show.
+ */
+export const hasVideoMeeting = (event: {
+  conference: EventConference | null
+  location: string | null
+}): boolean => !!event.conference || !!detectConference(event.location)
+
 /** The conference provider renCal can provision for events on this calendar, if any. */
 export const calendarConferenceProvider = (calendar?: Calendar): ConferenceProvider | null =>
   calendar?.provider === "google" ? "google" : null

--- a/src/lib/conference.ts
+++ b/src/lib/conference.ts
@@ -4,6 +4,8 @@ import type {
   EventConference as RpcEventConference,
 } from "@/rpc/bindings"
 
+import type { EventDateInfo } from "./event-time"
+
 export type ConferenceProvider = "google" | "outlook" | "proton"
 
 export type EventConference =
@@ -50,6 +52,27 @@ export const hasVideoMeeting = (event: {
   conference: EventConference | null
   location: string | null
 }): boolean => !!event.conference || !!detectConference(event.location)
+
+/**
+ * The link to join an event's video meeting: a live conference first, else a
+ * known meeting link in its location. Requested conferences have no link yet.
+ */
+export const getMeetingUrl = (event: {
+  conference: EventConference | null
+  location: string | null
+}): string | null =>
+  event.conference?.status === "live"
+    ? event.conference.url
+    : (detectConference(event.location)?.url ?? null)
+
+/** How long before an event starts that its "Join" button appears. */
+export const JOIN_LEAD_MINUTES = 10
+
+/** Whether an event is about to start, or still in progress, so a "Join" button makes sense. */
+export const isWithinJoinWindow = (
+  dateInfo: Pick<EventDateInfo, "startMs" | "endMs">,
+  nowMs: number,
+): boolean => nowMs >= dateInfo.startMs - JOIN_LEAD_MINUTES * 60_000 && nowMs < dateInfo.endMs
 
 /** The conference provider renCal can provision for events on this calendar, if any. */
 export const calendarConferenceProvider = (calendar?: Calendar): ConferenceProvider | null =>

--- a/src/lib/event-time.test.ts
+++ b/src/lib/event-time.test.ts
@@ -197,6 +197,16 @@ describe("toAllDay / toTimedAtStartOfDay", () => {
   })
 })
 
+describe("computeEventDateInfo epoch projections", () => {
+  it("projects start and end to epoch ms", () => {
+    const tz = getViewerTzid()
+    const start = zoned("2026-04-28T10:00:00", tz)
+    const end = zoned("2026-04-28T10:30:00", tz)
+    const { startMs, endMs } = computeEventDateInfo(start, end)
+    expect(endMs - startMs).toBe(30 * 60_000)
+  })
+})
+
 describe("computeEventDateInfo day range", () => {
   it("all-day single-day occupies one day (DTEND exclusive)", () => {
     const start = date("2026-04-28")

--- a/src/lib/event-time/layout.ts
+++ b/src/lib/event-time/layout.ts
@@ -24,6 +24,7 @@ export function computeEventDateInfo(start: EventTime, end: EventTime): EventDat
   const firstDay = dayOf(start)
   const endDay = dayOf(end)
   const startMs = instantForOrdering(start).epochMilliseconds
+  const endMs = instantForOrdering(end).epochMilliseconds
   const lastDay = lastOccupiedDay(start, end, firstDay)
 
   let startLocalMinutes = 0
@@ -35,5 +36,5 @@ export function computeEventDateInfo(start: EventTime, end: EventTime): EventDat
     endLocalMinutes = endZ.hour * 60 + endZ.minute
   }
 
-  return { startMs, firstDay, lastDay, endDay, startLocalMinutes, endLocalMinutes }
+  return { startMs, endMs, firstDay, lastDay, endDay, startLocalMinutes, endLocalMinutes }
 }

--- a/src/lib/event-time/types.ts
+++ b/src/lib/event-time/types.ts
@@ -14,6 +14,8 @@ export type EventTimeRange = {
 export type EventDateInfo = {
   /** Start projection in epoch ms; used as a sort key. */
   startMs: number
+  /** End projection in epoch ms; used with `startMs` to check if an event is ongoing. */
+  endMs: number
   /** Epoch-day key for the start's day in the viewer's zone. */
   firstDay: number
   /** Epoch-day key for the last occupied day, iCal-end-exclusive aware. */


### PR DESCRIPTION
Some quality-of-life improvements in the Agenda view for when video meetings are detected:

- Show video icon next to time
- Show "Join" button when meeting is about to start, or is ongoing

<img width="710" height="278" alt="CleanShot 2026-09-04 at 15 23 14@2x" src="https://github.com/user-attachments/assets/909fa9c1-9ec7-40af-a84f-2367bf6f7f9e" />
