### PR TITLE
Pin caldir-core and providers to one caldir release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,13 @@ jobs:
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
       version: ${{ steps.check.outputs.version }}
-      caldir_tag: ${{ steps.check.outputs.caldir_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Determine rencal version and latest caldir tag
+      - name: Determine rencal version
         id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version=$(jq -r .version package.json)
           tag="v${version}"
@@ -34,10 +31,6 @@ jobs:
             echo "Tag ${tag} does not exist, will release"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
-          # Use latest github release for caldir-core + providers:
-          caldir_tag=$(gh release view --repo t4t5/caldir --json tagName -q .tagName)
-          echo "caldir_tag=${caldir_tag}" >> "$GITHUB_OUTPUT"
-          echo "Using caldir ${caldir_tag}"
 
   build:
     needs: check-version
@@ -108,22 +101,11 @@ jobs:
             src-tauri/Cargo.toml > src-tauri/Cargo.toml.tmp
           mv src-tauri/Cargo.toml.tmp src-tauri/Cargo.toml
 
-      - name: Download caldir provider binaries
+      - name: Install caldir provider binaries
         working-directory: rencal
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CALDIR_TAG: ${{ needs.check-version.outputs.caldir_tag }}
           CALDIR_TARGET: ${{ matrix.caldir-target }}
-        run: |
-          mkdir -p src-tauri/providers
-          gh release download "$CALDIR_TAG" \
-            --repo t4t5/caldir \
-            --pattern "caldir-${CALDIR_TARGET}.tar.gz" \
-            --output caldir-release.tar.gz
-          tar -xzf caldir-release.tar.gz -C src-tauri/providers/
-          rm -f src-tauri/providers/caldir
-          chmod +x src-tauri/providers/caldir-provider-*
-          rm caldir-release.tar.gz
+        run: scripts/install-caldir-providers.sh
 
       - name: Import Apple signing certificate
         if: matrix.runner == 'macos-latest'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ renCal reads calendars/events from the local caldir directory via `caldir-core`.
 
 Provider credential field IDs come from the caldir provider binaries.
 
+`caldir-core` and the provider binaries are pinned to one caldir release tag in `src-tauri/Cargo.toml` (`[workspace.dependencies]`). Change it with `just bump-caldir <tag>`, which also regenerates `src-tauri/caldir-providers.sha256`; never edit the tag or the checksum file by hand.
+
 ## Event date/time rules
 
 - Read `docs/event-time-system.md` before changing event date/time logic.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ One caldir release tag in `src-tauri/Cargo.toml` pins both the `caldir-core` cra
 just bump-caldir v0.13.2
 ```
 
-To develop against a local caldir checkout (`../caldir` by default), build the providers from it with `just build-providers-local`. For `caldir-core` itself, add a patch to `src-tauri/Cargo.toml`:
+To develop against a local caldir checkout (`../caldir` by default), build the providers from it with `just build-providers-local`. For `caldir-core` itself, create a gitignored `.cargo/config.toml` in the repo root that patches the crate to the checkout (the path is relative to the repo root):
 
 ```toml
 [patch."https://github.com/t4t5/caldir"]
-caldir-core = { path = "../../caldir/caldir-core" }
+caldir-core = { path = "../caldir/caldir-core" }
 ```
+
+This also rewrites `src-tauri/Cargo.lock`, so don't commit that change. Delete `.cargo/config.toml` and `src-tauri/providers/` to go back to the pinned release.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ Use [`just`](https://just.systems/) to access handy development commands.
 # Start the Tauri app:
 just dev
 ```
+
+The first run downloads the pinned caldir provider binaries for your platform.
+Later runs reuse the binaries in `src-tauri/providers/`.

--- a/README.md
+++ b/README.md
@@ -67,5 +67,18 @@ Use [`just`](https://just.systems/) to access handy development commands.
 just dev
 ```
 
-The first run downloads the pinned caldir provider binaries for your platform.
+The first run downloads the caldir provider binaries for your platform.
 Later runs reuse the binaries in `src-tauri/providers/`.
+
+One caldir release tag in `src-tauri/Cargo.toml` pins both the `caldir-core` crate and the provider binaries. To move to a new caldir release:
+
+```bash
+just bump-caldir v0.13.2
+```
+
+To develop against a local caldir checkout (`../caldir` by default), build the providers from it with `just build-providers-local`. For `caldir-core` itself, add a patch to `src-tauri/Cargo.toml`:
+
+```toml
+[patch."https://github.com/t4t5/caldir"]
+caldir-core = { path = "../../caldir/caldir-core" }
+```

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ format-rust:
   cargo fmt --all
 
 # Run app (dev mode)
-dev: build-providers
+dev: ensure-providers
   pnpm tauri dev
 
 # Run website docs (dev mode)
@@ -52,7 +52,7 @@ test:
   pnpm test
 
 # Run app with frontend debug logging enabled. Pass a namespace to narrow it, e.g. `just debug month-scroll`.
-debug flags="*": build-providers
+debug flags="*": ensure-providers
   VITE_RENCAL_DEBUG={{flags}} pnpm tauri dev
 
 # Analyze which parts of app are slow based on ChromeDevTool recording:
@@ -68,7 +68,7 @@ bundlesize:
   npx vite-bundle-visualizer
 
 # Build the app for production
-build: build-providers-release
+build: ensure-providers
   #!/usr/bin/env bash
   set -euo pipefail
   # Linux deb/rpm bundles ship the reminder daemon — build it first so
@@ -79,7 +79,7 @@ build: build-providers-release
   NO_STRIP=true pnpm tauri build --config '{ "bundle": { "createUpdaterArtifacts": false } }'
 
 # Build, sign, and notarize the app for distribution (requires .env with Apple credentials)
-notarize: build-providers-release
+notarize: ensure-providers
   #!/usr/bin/env bash
   set -euo pipefail
   set -a && source .env && set +a
@@ -90,27 +90,9 @@ notarize: build-providers-release
   # Updater artifacts (and their signing key) are produced in CI, not here.
   NO_STRIP=true pnpm tauri build --config '{ "bundle": { "createUpdaterArtifacts": false } }'
 
-# Build caldir provider binaries (debug) into src-tauri/providers/
-build-providers:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  mkdir -p src-tauri/providers
-  providers=(google icloud outlook caldav webcal)
-  cargo build --manifest-path ../caldir/Cargo.toml "${providers[@]/#/--package=caldir-provider-}"
-  for p in "${providers[@]}"; do
-    cp "../caldir/target/debug/caldir-provider-$p" src-tauri/providers/
-  done
-
-# Build caldir provider binaries (release) into src-tauri/providers/
-build-providers-release:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  mkdir -p src-tauri/providers
-  providers=(google icloud outlook caldav webcal)
-  cargo build --manifest-path ../caldir/Cargo.toml "${providers[@]/#/--package=caldir-provider-}"
-  for p in "${providers[@]}"; do
-    cp "../caldir/target/release/caldir-provider-$p" src-tauri/providers/
-  done
+# Download the pinned caldir provider binaries when they are not already installed.
+ensure-providers:
+  scripts/install-caldir-providers.sh
 
 # ---- NOTIFICATIONS
 
@@ -181,4 +163,3 @@ deeplink-dev:
 deeplink-prod:
   xdg-mime default renCal.desktop x-scheme-handler/rencal
   rm -f ~/.local/share/applications/rencal-handler.desktop
-

--- a/justfile
+++ b/justfile
@@ -90,9 +90,17 @@ notarize: ensure-providers
   # Updater artifacts (and their signing key) are produced in CI, not here.
   NO_STRIP=true pnpm tauri build --config '{ "bundle": { "createUpdaterArtifacts": false } }'
 
-# Download the pinned caldir provider binaries when they are not already installed.
+# Download the caldir provider binaries pinned in src-tauri/Cargo.toml, unless already installed.
 ensure-providers:
   scripts/install-caldir-providers.sh
+
+# Move caldir-core and the provider binaries to a caldir release, e.g. `just bump-caldir v0.13.1`.
+bump-caldir tag:
+  scripts/bump-caldir.sh {{tag}}
+
+# Build the providers from a local caldir checkout instead of the pinned release. Delete src-tauri/providers/ to undo.
+build-providers-local caldir_repo="../caldir":
+  scripts/build-local-caldir-providers.sh {{caldir_repo}}
 
 # ---- NOTIFICATIONS
 

--- a/scripts/build-local-caldir-providers.sh
+++ b/scripts/build-local-caldir-providers.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Build the provider binaries from a local caldir checkout instead of the pinned release.
+# Usage: scripts/build-local-caldir-providers.sh [caldir_repo]  (default: ../caldir, relative to the repo root)
+# Delete src-tauri/providers/ to go back to the pinned release.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+readonly caldir_repo="${1:-../caldir}"
+readonly providers_dir="src-tauri/providers"
+readonly -a providers=(google icloud outlook caldav webcal)
+
+if [[ ! -f "$caldir_repo/Cargo.toml" ]]; then
+  echo "No caldir checkout found at $caldir_repo." >&2
+  exit 1
+fi
+
+cargo build --manifest-path "$caldir_repo/Cargo.toml" "${providers[@]/#/--package=caldir-provider-}"
+
+mkdir -p "$providers_dir"
+for provider in "${providers[@]}"; do
+  cp "$caldir_repo/target/debug/caldir-provider-$provider" "$providers_dir/"
+done
+
+echo "local $caldir_repo" > "$providers_dir/.caldir-version"
+echo "Installed caldir providers built from $caldir_repo."

--- a/scripts/bump-caldir.sh
+++ b/scripts/bump-caldir.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Move caldir-core and the provider binaries to a caldir release, e.g. `scripts/bump-caldir.sh v0.13.1`.
+# Regenerates src-tauri/caldir-providers.sha256 from the release's asset digests.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <tag>" >&2
+  exit 1
+fi
+
+readonly tag="$1"
+readonly manifest="src-tauri/Cargo.toml"
+readonly checksums="src-tauri/caldir-providers.sha256"
+readonly -a targets=(
+  aarch64-apple-darwin
+  x86_64-apple-darwin
+  aarch64-unknown-linux-musl
+  x86_64-unknown-linux-musl
+)
+
+trap 'rm -f "$checksums.tmp"' EXIT
+
+{
+  echo "# caldir $tag release assets. Regenerate with: just bump-caldir <tag>"
+  gh api "repos/t4t5/caldir/releases/tags/$tag" \
+    --jq '.assets[] | select(.name | startswith("caldir-")) | "\(.digest | ltrimstr("sha256:"))  \(.name)"'
+} > "$checksums.tmp"
+
+for target in "${targets[@]}"; do
+  if ! grep -Eq "^[0-9a-f]{64}  caldir-$target\.tar\.gz$" "$checksums.tmp"; then
+    echo "Release $tag has no sha256 digest for caldir-$target.tar.gz." >&2
+    exit 1
+  fi
+done
+
+mv "$checksums.tmp" "$checksums"
+
+# -i.bak works on both GNU and BSD sed.
+sed -i.bak -E "s|^(caldir-core = .*tag = \")[^\"]*(\".*)$|\1$tag\2|" "$manifest"
+rm "$manifest.bak"
+grep -q "^caldir-core = .*tag = \"$tag\"" "$manifest"
+
+cargo fetch --manifest-path "$manifest"
+scripts/install-caldir-providers.sh

--- a/scripts/install-caldir-providers.sh
+++ b/scripts/install-caldir-providers.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly caldir_binaries_release="v0.13.1"
+readonly providers_dir="src-tauri/providers"
+readonly version_file="$providers_dir/.caldir-version"
+readonly -a providers=(google icloud outlook caldav webcal)
+
+if [[ -n "${CALDIR_TARGET:-}" ]]; then
+  target="$CALDIR_TARGET"
+else
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64 | Darwin:aarch64) target="aarch64-apple-darwin" ;;
+    Darwin:x86_64) target="x86_64-apple-darwin" ;;
+    Linux:aarch64 | Linux:arm64) target="aarch64-unknown-linux-musl" ;;
+    Linux:x86_64) target="x86_64-unknown-linux-musl" ;;
+    *)
+      echo "No prebuilt caldir providers are available for $(uname -s) $(uname -m)." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+providers_are_current() {
+  [[ -f "$version_file" ]] || return 1
+  [[ "$(<"$version_file")" == "$caldir_binaries_release $target" ]] || return 1
+
+  local provider
+  for provider in "${providers[@]}"; do
+    [[ -x "$providers_dir/caldir-provider-$provider" ]] || return 1
+  done
+}
+
+case "$target" in
+  aarch64-apple-darwin)
+    checksum="d007d20259c27b51be5690fdb36033218b8a259f5a342b627baded251104e0d7"
+    ;;
+  x86_64-apple-darwin)
+    checksum="ff0495a0bd21c296ab5b5686d521cdce4506e6c21e10cb3e769343b71c300fc8"
+    ;;
+  aarch64-unknown-linux-musl)
+    checksum="0c212791751f053ce32efdd1f232a48552460247b001e1cc7a13fc613416511f"
+    ;;
+  x86_64-unknown-linux-musl)
+    checksum="9990fead337e581ce1a6db0af41fbd0436c9a8672880864e4ebe7845254b4c57"
+    ;;
+  *)
+    echo "No prebuilt caldir providers are available for target $target." >&2
+    exit 1
+    ;;
+esac
+
+if providers_are_current; then
+  exit 0
+fi
+
+archive="caldir-$target.tar.gz"
+url="https://github.com/t4t5/caldir/releases/download/$caldir_binaries_release/$archive"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "Downloading caldir providers $caldir_binaries_release for $target..."
+curl --fail --location --retry 3 --show-error --silent \
+  --output "$tmp_dir/$archive" \
+  "$url"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_checksum="$(sha256sum "$tmp_dir/$archive" | cut -d ' ' -f 1)"
+else
+  actual_checksum="$(shasum -a 256 "$tmp_dir/$archive" | cut -d ' ' -f 1)"
+fi
+
+if [[ "$actual_checksum" != "$checksum" ]]; then
+  echo "Checksum verification failed for $archive." >&2
+  echo "Expected: $checksum" >&2
+  echo "Actual:   $actual_checksum" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp_dir/$archive" -C "$tmp_dir"
+mkdir -p "$providers_dir"
+
+for provider in "${providers[@]}"; do
+  binary="caldir-provider-$provider"
+  if [[ ! -f "$tmp_dir/$binary" ]]; then
+    echo "The downloaded archive does not contain $binary." >&2
+    exit 1
+  fi
+  install -m 755 "$tmp_dir/$binary" "$providers_dir/$binary"
+done
+
+printf '%s %s\n' "$caldir_binaries_release" "$target" > "$version_file"
+echo "Installed caldir providers $caldir_binaries_release."

--- a/scripts/install-caldir-providers.sh
+++ b/scripts/install-caldir-providers.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
+# Install the caldir provider binaries for the caldir release pinned in src-tauri/Cargo.toml.
 set -euo pipefail
 
-readonly caldir_binaries_release="v0.13.1"
+cd "$(dirname "$0")/.."
+
+readonly manifest="src-tauri/Cargo.toml"
+readonly checksums_file="src-tauri/caldir-providers.sha256"
 readonly providers_dir="src-tauri/providers"
 readonly version_file="$providers_dir/.caldir-version"
 readonly -a providers=(google icloud outlook caldav webcal)
+
+# The pinned tag is the one on the caldir-core line under [workspace.dependencies].
+tag="$(sed -n 's/^caldir-core = .*tag = "\([^"]*\)".*/\1/p' "$manifest")"
+if [[ -z "$tag" ]]; then
+  echo "Could not read the caldir release tag from the caldir-core line in $manifest." >&2
+  exit 1
+fi
 
 if [[ -n "${CALDIR_TARGET:-}" ]]; then
   target="$CALDIR_TARGET"
@@ -21,9 +32,14 @@ else
   esac
 fi
 
+if [[ -f "$version_file" && "$(<"$version_file")" == local* ]]; then
+  echo "Using locally built caldir providers ($(<"$version_file")). Delete $providers_dir to go back to caldir $tag." >&2
+  exit 0
+fi
+
 providers_are_current() {
   [[ -f "$version_file" ]] || return 1
-  [[ "$(<"$version_file")" == "$caldir_binaries_release $target" ]] || return 1
+  [[ "$(<"$version_file")" == "$tag $target" ]] || return 1
 
   local provider
   for provider in "${providers[@]}"; do
@@ -31,35 +47,29 @@ providers_are_current() {
   done
 }
 
-case "$target" in
-  aarch64-apple-darwin)
-    checksum="d007d20259c27b51be5690fdb36033218b8a259f5a342b627baded251104e0d7"
-    ;;
-  x86_64-apple-darwin)
-    checksum="ff0495a0bd21c296ab5b5686d521cdce4506e6c21e10cb3e769343b71c300fc8"
-    ;;
-  aarch64-unknown-linux-musl)
-    checksum="0c212791751f053ce32efdd1f232a48552460247b001e1cc7a13fc613416511f"
-    ;;
-  x86_64-unknown-linux-musl)
-    checksum="9990fead337e581ce1a6db0af41fbd0436c9a8672880864e4ebe7845254b4c57"
-    ;;
-  *)
-    echo "No prebuilt caldir providers are available for target $target." >&2
-    exit 1
-    ;;
-esac
-
 if providers_are_current; then
   exit 0
 fi
 
+checksums_tag="$(sed -n 's/^# caldir \(v[^ ]*\) .*/\1/p' "$checksums_file")"
+if [[ "$checksums_tag" != "$tag" ]]; then
+  echo "$checksums_file is for caldir $checksums_tag but $manifest pins $tag." >&2
+  echo "Run: just bump-caldir $tag" >&2
+  exit 1
+fi
+
 archive="caldir-$target.tar.gz"
-url="https://github.com/t4t5/caldir/releases/download/$caldir_binaries_release/$archive"
+checksum="$(awk -v name="$archive" '$2 == name { print $1 }' "$checksums_file")"
+if [[ ${#checksum} -ne 64 ]]; then
+  echo "No checksum for $archive in $checksums_file: no prebuilt caldir providers for target $target." >&2
+  exit 1
+fi
+
+url="https://github.com/t4t5/caldir/releases/download/$tag/$archive"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-echo "Downloading caldir providers $caldir_binaries_release for $target..."
+echo "Downloading caldir providers $tag for $target..."
 curl --fail --location --retry 3 --show-error --silent \
   --output "$tmp_dir/$archive" \
   "$url"
@@ -89,5 +99,5 @@ for provider in "${providers[@]}"; do
   install -m 755 "$tmp_dir/$binary" "$providers_dir/$binary"
 done
 
-printf '%s %s\n' "$caldir_binaries_release" "$target" > "$version_file"
-echo "Installed caldir providers $caldir_binaries_release."
+printf '%s %s\n' "$tag" "$target" > "$version_file"
+echo "Installed caldir providers $tag."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -551,9 +551,8 @@ dependencies = [
 
 [[package]]
 name = "caldir-core"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2350b58579e35f1ab040307f2bd5dc97fcef73fcdbe3bde81b2dea2be73b2263"
+version = "0.14.3"
+source = "git+https://github.com/t4t5/caldir?tag=v0.13.1#cc07b1d475500f0a7ab35f9bd11fcb86bc253f0f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 members = ["reminder-core", "notifierd", "rencal-config"]
 
+[workspace.dependencies]
+# One caldir tag pins both caldir-core and the provider binaries; bump with `just bump-caldir <tag>`.
+caldir-core = { git = "https://github.com/t4t5/caldir", tag = "v0.13.1" }
+
 [package]
 name = "rencal"
 version = "0.0.1"
@@ -35,7 +39,7 @@ tokio = { version = "1", features = ["full"] }
 url = "2.5"
 anyhow = "1.0.100"
 socket2 = "0.5"
-caldir-core = "0.14.2"
+caldir-core = { workspace = true }
 chrono = "0.4.43"
 reminder-core = { path = "reminder-core" }
 rencal-config = { path = "rencal-config" }

--- a/src-tauri/caldir-providers.sha256
+++ b/src-tauri/caldir-providers.sha256
@@ -1,0 +1,6 @@
+# caldir v0.13.1 release assets. Regenerate with: just bump-caldir <tag>
+d007d20259c27b51be5690fdb36033218b8a259f5a342b627baded251104e0d7  caldir-aarch64-apple-darwin.tar.gz
+0c212791751f053ce32efdd1f232a48552460247b001e1cc7a13fc613416511f  caldir-aarch64-unknown-linux-musl.tar.gz
+ff0495a0bd21c296ab5b5686d521cdce4506e6c21e10cb3e769343b71c300fc8  caldir-x86_64-apple-darwin.tar.gz
+8e68194b005c06593959c5f022ffb72e3471e5377a4cd4a19816b6835261a054  caldir-x86_64-pc-windows-msvc.zip
+9990fead337e581ce1a6db0af41fbd0436c9a8672880864e4ebe7845254b4c57  caldir-x86_64-unknown-linux-musl.tar.gz

--- a/src-tauri/reminder-core/Cargo.toml
+++ b/src-tauri/reminder-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-caldir-core = "0.14.2"
+caldir-core = { workspace = true }
 chrono = { version = "0.4.43", features = ["serde"] }
 dirs = "5"
 log = "0.4.29"


### PR DESCRIPTION
`caldir-core` and the provider binaries were previously versioned independently: the crate came from crates.io, the binaries from whatever the latest caldir GitHub release was at build time.

Not only could the two silently drift apart, but local development also had a hidden requirement for a caldir checkout at `../caldir`, which made it hard to work on renCal in worktrees with tools like herdr.

This PR instead pins both to a single caldir release tag in `src-tauri/Cargo.toml`: `caldir-core` becomes a git dependency on that tag, and the provider binaries are downloaded from the same release and checksum-verified.

`just bump-caldir <tag>` is the one way to move to a new release: it updates the tag, regenerates the checksum file, refreshes `Cargo.lock`, and reinstalls the providers. Caldir updates no longer flow into renCal releases automatically; bumping is an explicit commit.