### PR TITLE
Show keyboard shortcuts as sidebar

### DIFF
--- a/src/components/shortcuts/ShortcutsOverlay.tsx
+++ b/src/components/shortcuts/ShortcutsOverlay.tsx
@@ -1,46 +1,112 @@
+import { useMemo, useState } from "react"
+
 import { ShortcutKeys } from "@/components/shortcuts/ShortcutKeys"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 
 import { ShortcutDef, ShortcutGroup, SHORTCUT_GROUPS, SHORTCUTS } from "@/lib/shortcuts"
 
-export function ShortcutsOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
-  return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Keyboard shortcuts</DialogTitle>
-        </DialogHeader>
+import { CloseIcon } from "@/icons/close"
+import { SearchIcon } from "@/icons/search"
 
-        <div className="flex flex-col gap-5">
-          {SHORTCUT_GROUPS.map((group) => (
-            <ShortcutGroupSection key={group} group={group} />
-          ))}
+export function ShortcutsOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [query, setQuery] = useState("")
+  const normalizedQuery = query.trim().toLowerCase()
+  const filteredShortcuts = useMemo(
+    () =>
+      normalizedQuery
+        ? SHORTCUTS.filter(
+            (shortcut) =>
+              shortcut.label.toLowerCase().includes(normalizedQuery) ||
+              shortcut.group.toLowerCase().includes(normalizedQuery) ||
+              shortcut.bindings.some(
+                (binding) =>
+                  !("hidden" in binding && binding.hidden) &&
+                  binding.keys.toLowerCase().includes(normalizedQuery),
+              ),
+          )
+        : SHORTCUTS,
+    [normalizedQuery],
+  )
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose()
+      }}
+    >
+      <SheetContent className="w-full gap-0 p-0 sm:max-w-md">
+        <SheetHeader className="shrink-0 gap-4 border-b p-5">
+          <div className="flex items-center justify-between gap-4">
+            <SheetTitle className="text-lg">Keyboard shortcuts</SheetTitle>
+
+            <SheetClose asChild>
+              <Button variant="ghost" size="icon-sm" aria-label="Close keyboard shortcuts">
+                <CloseIcon />
+              </Button>
+            </SheetClose>
+          </div>
+
+          <div className="relative">
+            <SearchIcon className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              autoFocus
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Find keyboard shortcuts"
+              aria-label="Find keyboard shortcuts"
+              ghost={false}
+              className="h-10 pr-3 pl-9"
+            />
+          </div>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4">
+          {filteredShortcuts.length > 0 ? (
+            <div className="flex flex-col gap-7 pb-4">
+              {SHORTCUT_GROUPS.map((group) => (
+                <ShortcutGroupSection key={group} group={group} shortcuts={filteredShortcuts} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground py-10 text-center text-sm">No shortcuts found</p>
+          )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }
 
-function ShortcutGroupSection({ group }: { group: ShortcutGroup }) {
-  return (
-    <div className="flex flex-col gap-1">
-      <h3 className="text-muted-foreground pb-1 text-xs font-medium tracking-wide uppercase">
-        {group}
-      </h3>
+function ShortcutGroupSection({
+  group,
+  shortcuts,
+}: {
+  group: ShortcutGroup
+  shortcuts: readonly ShortcutDef[]
+}) {
+  const groupShortcuts = shortcuts.filter((shortcut) => shortcut.group === group)
+  if (groupShortcuts.length === 0) return null
 
-      {SHORTCUTS.filter((shortcut) => shortcut.group === group).map((shortcut) => (
+  return (
+    <section className="flex flex-col gap-2">
+      <h3 className="text-foreground text-sm font-semibold">{group}</h3>
+
+      {groupShortcuts.map((shortcut) => (
         <ShortcutRow key={shortcut.id} shortcut={shortcut} />
       ))}
-    </div>
+    </section>
   )
 }
 
 function ShortcutRow({ shortcut }: { shortcut: ShortcutDef }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-0.5 text-sm">
-      <span>{shortcut.label}</span>
+    <div className="flex min-h-8 items-center justify-between gap-4 text-sm">
+      <span className="text-muted-foreground">{shortcut.label}</span>
 
-      <div className="flex items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-1.5">
         {shortcut.bindings
           .filter((binding) => !binding.hidden)
           .map((binding, i) => (


### PR DESCRIPTION
Cleaner than a modal. Also scrollable, which is useful as the list of commands grows.

<img width="1078" height="1314" alt="image" src="https://github.com/user-attachments/assets/60075175-fd1a-4a8c-abeb-640c22c9c779" />
