### PR TITLE
Tweak invites badge and popover

### DIFF
--- a/src-tauri/src/routes/caldir/list_invites.rs
+++ b/src-tauri/src/routes/caldir/list_invites.rs
@@ -3,11 +3,9 @@ use super::helpers::{event_time_sort_key, is_visible};
 use super::types::CalendarEvent;
 use crate::event_cache::EVENT_CACHE;
 use crate::routes::TauResult;
-use chrono::Utc;
 
 pub(super) async fn handler(calendar_slugs: Vec<String>) -> TauResult<Vec<CalendarEvent>> {
     let caldir = load_caldir()?;
-    let now = Utc::now();
     let mut invites = Vec::new();
 
     for slug in &calendar_slugs {
@@ -23,13 +21,7 @@ pub(super) async fn handler(calendar_slugs: Vec<String>) -> TauResult<Vec<Calend
             if !is_visible(event) {
                 continue;
             }
-            let is_future = event
-                .end
-                .as_ref()
-                .map(|e| e.to_utc())
-                .unwrap_or_else(|| event.start.to_utc())
-                >= now;
-            if event.is_pending_invite_for(&email) && is_future {
+            if event.is_pending_invite_for(&email) {
                 invites.push(CalendarEvent::from_event(event, slug, None));
             }
         }

--- a/src/components/shortcuts/GlobalShortcuts.tsx
+++ b/src/components/shortcuts/GlobalShortcuts.tsx
@@ -11,6 +11,7 @@ import {
   isAgendaItemFocused,
   isInteractiveElementFocused,
 } from "@/components/sidebar/agenda/useAgendaKeyboardNav"
+import { INVITES_BUTTON_EL_ID } from "@/components/toolbar/InvitesBadge"
 import { openSettingsWindow } from "@/components/toolbar/SettingsButton"
 import { SEARCH_BUTTON_EL_ID } from "@/components/toolbar/search/SearchButton"
 
@@ -289,6 +290,10 @@ function useShortcutHandlers({
     search: handleSearch,
     "compose-event": handleComposeEvent,
     "add-event": handleAddEventToActiveDay,
+    "toggle-invites": (e) => {
+      e?.preventDefault()
+      document.getElementById(INVITES_BUTTON_EL_ID)?.click()
+    },
     sync: () => void syncNow(),
     settings: (e) => {
       e?.preventDefault()

--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -1,5 +1,5 @@
 import { Temporal } from "@js-temporal/polyfill"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { RsvpBar } from "@/components/event-parts/inputs/RsvpBar"
 import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils"
 export const INVITES_BUTTON_EL_ID = "global-invites-button"
 
 export function InvitesBadge() {
+  const restoringFocusRef = useRef(false)
   const { calendars } = useCalendars()
   const [pendingInvites, setPendingInvites] = useState<CalendarEvent[]>([])
   const today = useToday()
@@ -63,13 +64,27 @@ export function InvitesBadge() {
           <button
             id={INVITES_BUTTON_EL_ID}
             aria-label="Invitations"
+            onFocus={(event) => {
+              if (restoringFocusRef.current) event.preventDefault()
+            }}
             className="flex size-6 items-center justify-center rounded-full bg-highlight text-xs font-medium text-white hover:bg-highlight/90 transition-colors outline-none"
           >
             {invites.length}
           </button>
         </PopoverTrigger>
       </ShortcutTooltip>
-      <PopoverContent align={isMd ? "start" : "end"} collisionPadding={16} className="w-80 p-0">
+      <PopoverContent
+        align={isMd ? "start" : "end"}
+        collisionPadding={16}
+        className="w-80 p-0"
+        onCloseAutoFocus={() => {
+          // Radix restores focus synchronously; keep that focus from reopening the tooltip.
+          restoringFocusRef.current = true
+          queueMicrotask(() => {
+            restoringFocusRef.current = false
+          })
+        }}
+      >
         <PopoverArrow />
         <div className="p-3 font-medium text-sm border-b">Invitations</div>
         <div className="max-h-80 overflow-y-auto">

--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 
 import { RsvpBar } from "@/components/event-parts/inputs/RsvpBar"
 import { Popover, PopoverArrow, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { ShortcutTooltip } from "@/components/ui/shortcut-tooltip"
 
 import { rpc } from "@/rpc"
 import type { ResponseStatus, TimeFormat } from "@/rpc/bindings"
@@ -16,6 +17,8 @@ import { useToday } from "@/hooks/useToday"
 import { eventKey, rpcToCalendarEvents, type CalendarEvent } from "@/lib/cal-events"
 import { dateInViewerZone, formatShortDate, formatTime } from "@/lib/event-time"
 import { cn } from "@/lib/utils"
+
+export const INVITES_BUTTON_EL_ID = "global-invites-button"
 
 export function InvitesBadge() {
   const { calendars } = useCalendars()
@@ -55,11 +58,17 @@ export function InvitesBadge() {
 
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <button className="flex size-6 items-center justify-center rounded-full bg-highlight text-xs font-medium text-white hover:bg-highlight/90 transition-colors outline-none">
-          {invites.length}
-        </button>
-      </PopoverTrigger>
+      <ShortcutTooltip text="Invitations" shortcut="i">
+        <PopoverTrigger asChild>
+          <button
+            id={INVITES_BUTTON_EL_ID}
+            aria-label="Invitations"
+            className="flex size-6 items-center justify-center rounded-full bg-highlight text-xs font-medium text-white hover:bg-highlight/90 transition-colors outline-none"
+          >
+            {invites.length}
+          </button>
+        </PopoverTrigger>
+      </ShortcutTooltip>
       <PopoverContent align={isMd ? "start" : "end"} collisionPadding={16} className="w-80 p-0">
         <PopoverArrow />
         <div className="p-3 font-medium text-sm border-b">Invitations</div>

--- a/src/components/toolbar/InvitesBadge.tsx
+++ b/src/components/toolbar/InvitesBadge.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from "@js-temporal/polyfill"
 import { useEffect, useState } from "react"
 
 import { RsvpBar } from "@/components/event-parts/inputs/RsvpBar"
@@ -11,17 +12,20 @@ import { useSettings } from "@/contexts/SettingsContext"
 import { useSync } from "@/contexts/SyncContext"
 
 import { useBreakpoint } from "@/hooks/useBreakpoint"
-import { useViewerTzid } from "@/hooks/useViewerTzid"
+import { useToday } from "@/hooks/useToday"
 import { eventKey, rpcToCalendarEvents, type CalendarEvent } from "@/lib/cal-events"
 import { dateInViewerZone, formatShortDate, formatTime } from "@/lib/event-time"
 import { cn } from "@/lib/utils"
 
 export function InvitesBadge() {
   const { calendars } = useCalendars()
-  const [invites, setInvites] = useState<CalendarEvent[]>([])
+  const [pendingInvites, setPendingInvites] = useState<CalendarEvent[]>([])
+  const today = useToday()
 
-  // Invite rows show viewer-zone dates/times; re-render them on timezone change.
-  useViewerTzid()
+  // Keep today's invitations until local midnight, even after they've ended.
+  const invites = pendingInvites.filter(
+    (invite) => Temporal.PlainDate.compare(dateInViewerZone(invite.start), today) >= 0,
+  )
 
   useEffect(() => {
     const slugs = calendars.filter((c) => c.provider !== null).map((c) => c.slug)
@@ -29,7 +33,7 @@ export function InvitesBadge() {
 
     rpc.caldir
       .list_invites(slugs)
-      .then((events) => setInvites(rpcToCalendarEvents(events)))
+      .then((events) => setPendingInvites(rpcToCalendarEvents(events)))
       .catch(console.error)
   }, [calendars])
 
@@ -40,7 +44,7 @@ export function InvitesBadge() {
   if (invites.length === 0) return null
 
   const handleRsvp = async (invite: CalendarEvent, response: ResponseStatus) => {
-    setInvites((prev) => prev.filter((i) => eventKey(i) !== eventKey(invite)))
+    setPendingInvites((prev) => prev.filter((i) => eventKey(i) !== eventKey(invite)))
     try {
       await rpc.caldir.rsvp(invite.calendar_slug, invite.id, response)
       void requestSync()
@@ -52,7 +56,7 @@ export function InvitesBadge() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button className="flex size-6 items-center justify-center rounded-full bg-red-500 text-xs font-medium text-white hover:bg-red-600 transition-colors outline-none">
+        <button className="flex size-6 items-center justify-center rounded-full bg-highlight text-xs font-medium text-white hover:bg-highlight/90 transition-colors outline-none">
           {invites.length}
         </button>
       </PopoverTrigger>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -46,7 +46,7 @@ function PopoverArrow({
   return (
     <PopoverPrimitive.Arrow
       data-slot="popover-arrow"
-      className={cn("fill-popover", className)}
+      className={cn("fill-card", className)}
       asChild
       width={width}
       height={height}
@@ -54,7 +54,7 @@ function PopoverArrow({
     >
       <svg viewBox="0 0 30 10" preserveAspectRatio="none">
         <polygon points="0,0 30,0 15,10" />
-        <polyline points="0,0 15,10 30,0" fill="none" className="stroke-border" strokeWidth={2} />
+        <polyline points="0,0 15,10 30,0" fill="none" className="stroke-divider" strokeWidth={2} />
       </svg>
     </PopoverPrimitive.Arrow>
   )

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -40,13 +40,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover/95 text-foreground shadow-button-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance gap-2 flex items-center",
+          "bg-tooltip text-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance gap-2 flex items-center",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-popover fill-popover z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-43 rounded-[2px] group-data-[side=bottom]:[clip-path:polygon(0_0,100%_0,0_100%)] group-data-[side=top]:[clip-path:polygon(100%_0,100%_100%,0_100%)] group-data-[side=left]:[clip-path:polygon(0_0,100%_0,100%_100%)] group-data-[side=right]:[clip-path:polygon(0_0,100%_100%,0_100%)] relative top-[1px]" />
+        <TooltipPrimitive.Arrow className="fill-tooltip" width={10} height={5} />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/src/global.css
+++ b/src/global.css
@@ -89,6 +89,8 @@ body {
   --popover: color-mix(in srgb, var(--popover-tint) var(--popover-mix), var(--background));
   --popover-foreground: var(--foreground);
 
+  --tooltip: color-mix(in srgb, var(--hover-tint) 15%, var(--background));
+
   --destructive: var(--error);
 
   --tab-list-shadow: inset 0 0 0 1px var(--secondary);
@@ -123,6 +125,7 @@ body {
 
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
+  --color-tooltip: var(--tooltip);
 
   --color-card: var(--card);
   --color-today: var(--today);

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -145,6 +145,12 @@ export const SHORTCUTS = [
     bindings: [{ keys: "a", type: "char" }],
   },
   {
+    id: "toggle-invites",
+    group: "General",
+    label: "Toggle invitations",
+    bindings: [{ keys: "i", type: "char" }],
+  },
+  {
     id: "sync",
     group: "General",
     label: "Sync now",

--- a/src/themes/README.md
+++ b/src/themes/README.md
@@ -89,6 +89,8 @@ The derived tokens (`--hover`, `--secondary`, `--accent`, `--card`, `--divider`,
 | `--popover-tint` | Popover depth tint (`black` for dark themes, `white` for light)   |
 | `--popover-mix`  | Percentage of popover tint mixed into the background              |
 
+Tooltips use a solid `--tooltip` surface derived from 15% `--hover-tint` mixed into `--background`, with a matching arrow.
+
 ### Structure
 
 | Variable          | Purpose                                     |

--- a/website/src/content/docs/docs/keyboard-shortcuts.md
+++ b/website/src/content/docs/docs/keyboard-shortcuts.md
@@ -36,6 +36,7 @@ Press <kbd>?</kbd> in the app to see all shortcuts.
 | Search events                    | <kbd>/</kbd> or <kbd>Ctrl</kbd><kbd>F</kbd> |
 | Compose a new event              | <kbd>c</kbd>                                |
 | Add an event to the selected day | <kbd>a</kbd>                                |
+| Toggle invitations               | <kbd>i</kbd>                                |
 | Open settings                    | <kbd>Ctrl</kbd><kbd>,</kbd>                 |
 | Cycle through themes             | <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>T</kbd> |
 | Show keyboard shortcuts          | <kbd>?</kbd>                                |


### PR DESCRIPTION
- Fixes the color of the invite badge (it wasn't using the theme variables).
- Add keyboard shortcut to toggle the invites popover (with <kbd>i</kbd>)
- Invitations only disappear at the end of the day of the event (otherwise users might be confused by event that was visible at one point and then not anymore, even if it's already passed)

### Before

<img width="1024" height="270" alt="screenshot-2026-09-10_17-00-25" src="https://github.com/user-attachments/assets/7a767414-9c30-4ab8-88ac-841c363a1e95" />


### After

<img width="994" height="270" alt="screenshot-2026-09-10_19-18-26" src="https://github.com/user-attachments/assets/55b104d1-43fe-4ac3-82d1-da9ed9b200a8" />
